### PR TITLE
top menu now stick to the right side

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -406,7 +406,7 @@ i.icon-opensource {
 
 @media (max-width: 1199px) and (min-width: 992px) {
 	.banner ul#menu-header.nav {
-		width: 80%;
+		width: inherit;
 		padding-top: 20px;
 	}
 
@@ -687,6 +687,13 @@ p.federation-id {
 }
 
 /** media queries **/
+@media (max-width: 991px) and (min-width: 768px) {
+  .banner ul#menu-header.nav{
+    width:inherit;
+    padding-top:20px;
+  }
+}
+
 @media (max-width: 991px) {
   .new-timeline li .new-timeline-panel {
     width: 44%;


### PR DESCRIPTION
fixes #15 

Also added one media query to fix another window width scenario, where the top menu was all over the place. (here at 871px)

<img width="871" alt="screen shot 2016-06-10 at 23 36 59" src="https://cloud.githubusercontent.com/assets/868272/15979441/4b125270-2f64-11e6-8c11-62d0d299fd15.png">


@mar1u5 branch is up for review