### PR TITLE
Replacing loader gif on Install page with text content

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -105,7 +105,7 @@ body {
 /* event image */
 
 .home-event-img {
-	height: 45%;
+	height: 40%;
 	margin: 0 0 0 0 !important;
 	position: absolute;
 	bottom:5%;
@@ -150,7 +150,7 @@ body {
 	}
 
 	.home-event-img {
-		height: 35%;
+		height: 114px;
 		margin: 0 0 0 0 !important;
 		position: absolute;
 		bottom:-100px;
@@ -194,10 +194,10 @@ body {
 	}
 
 	.home-event-img {
-		height: 30%;
+		height: 114px;
 		margin: 0 0 0 0 !important;
 		position: absolute;
-		bottom:-20px;
+		bottom:-60px;
 		left:5%;
 		/* IE 9 */
 		-ms-transform: rotate(-11deg);
@@ -239,7 +239,7 @@ body {
         }
 
         .home-event-img {
-			height: 35%;
+			height: 125px;
 			margin: 0 0 0 0 !important;
 			position: absolute;
 			bottom:-20px;
@@ -263,10 +263,10 @@ body {
 	}
 
 	.home-event-img {
-		height: 30%;
+		height: 175px;
 		margin: 0 0 0 0 !important;
 		position: absolute;
-		top:20%;
+		bottom: -40px;
 		left:5%;
 		/* IE 9 */
 		-ms-transform: rotate(-11deg);
@@ -292,10 +292,10 @@ only screen and ( min-resolution: 160dpi              ) and (min-width: 700px) a
 	}
 
 	.home-event-img {
-		height: 35%;
+		height: 175px;
 		margin: 0 0 0 0 !important;
 		position: absolute;
-		top:60%;
+		bottom: -40px;
 		left:5%;
 		/* IE 9 */
 		-ms-transform: rotate(-11deg);
@@ -385,7 +385,7 @@ only screen and ( min-resolution: 160dpi                 ) and (min-width: 992px
 		height: 35%;
 		margin: 0 0 0 0 !important;
 		position: absolute;
-		top:25%;
+		top:50%;
 		left:5%;
 		/* IE 9 */
 		-ms-transform: rotate(-11deg);

--- a/page-install.php
+++ b/page-install.php
@@ -1,13 +1,3 @@
-<div class="row">
-	<div class="col-md-6 col-md-offset-3 text-center">
-
-		<h1>Coming soon!</h1>
-	</div>
-	<div class="col-md-4 col-md-offset-4 text-center">
-		<img class="img-responsive" alt="animation from wikimedia commons" src="<?php bloginfo('template_directory'); ?>/assets/img/common/loading_big.gif" />
-	</div>
-	<div class="col-md-8 col-md-offset-2 text-center">
-		
-		<p>Over the coming weeks we'll provide stable and pre-release builds of Nextcloud right here.</p>
-	</div>
-</div>
+<h1>Coming soon!</h1>
+<p>We're working hard on desktop and mobile clients to bring Nextcloud to a variety of platforms. Download links will be added to this page as soon as they're ready.</p>
+<p>If you'd like to lend us a hand, <a href="/contribute/">get involved!</a></p>


### PR DESCRIPTION
As Nextcloud downloads aren't ready yet, the Install page features a large "loading" gif. It seems a bit misleading, as it gives the impression some content is loading on the page and might cause site visitors to sit and wait with the expectation that something on the page is about to change.

I propose updating the page with a brief paragraph of text instead, explaining that Nextcloud clients will be ready for download soon and providing a link to the Contribute page to encourage visitors to help with the project if they're interested.

The second commit in this PR is a fix for issue #20. I thought I could submit a separate PR for it and didn't mean it to be part of this one, but apparently it just got added here instead. Sorry if that's a bit untidy!