### PR TITLE
new collabora image needs a different main url

### DIFF
--- a/page-collaboraonline.php
+++ b/page-collaboraonline.php
@@ -154,7 +154,7 @@ docker run -t -d -p 127.0.0.1:9980:9980 -e 'domain=cloud\\.nextcloud\\.com' --re
   ProxyPassReverse    /hosting/discovery https://127.0.0.1:9980/hosting/discovery
 
   # Main websocket
-  ProxyPass   /lool/ws      wss://127.0.0.1:9980/lool/ws
+  ProxyPassMatch "/lool/(.*)/ws$" wss://127.0.0.1:9980/lool/$1/ws
 
   # Admin Console websocket
   ProxyPass   /lool/adminws wss://127.0.0.1:9980/lool/adminws


### PR DESCRIPTION
Line: 157:
ProxyPass /lool/ws wss://127.0.0.1:9980/lool/ws

ProxyPassMatch "/lool/(.*)/ws$" wss://127.0.0.1:9980/lool/$1/ws

as in post:
https://help.nextcloud.com/t/updated-collabora-now-unable-to-open-documents/4179/15