### PR TITLE
fix install page tabs

### DIFF
--- a/assets/css/old/styles.css
+++ b/assets/css/old/styles.css
@@ -319,6 +319,24 @@ button a:hover {text-decoration: none; }
 	background: #0082c9 !important;
 }
 
+.install-nav {
+    margin-bottom: 0;
+    padding-left: 0;
+    list-style: none;
+}
+
+.install-nav>li {
+	position: relative;
+    display: block;
+}
+
+.install-nav>li>a {
+	position: relative;
+    display: block;
+    padding: 10px 15px;
+	text-decoration: none;
+}
+	
 .menu-install:hover	{
 /* 	background: #428bca !important; */
 }


### PR DESCRIPTION
turns out our install page was broken due to the new nav bar... Fixed. Can't use the 'nav' class anymore, it breaks because it's been used in the new nav bar.