### PR TITLE
Make .nav bg-animation working in both directions

### DIFF
--- a/assets/css/header.scss
+++ b/assets/css/header.scss
@@ -526,6 +526,8 @@
 
 .nav {
     padding-bottom: 70px;
+	
+    transition: all .2s ease-in;
 
     @media (max-width: 992px) {
         padding-bottom: 20px; 
@@ -533,7 +535,7 @@
 
     &.scrolled {
         position: fixed;
-        transition: all .2s ease-in;
+        
         background: white;
         box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.09);
 


### PR DESCRIPTION
The transition attribute of the nav is just applied, if .scrolledis added while scrolling down from the top of the page on desktop devices. 
A more consistent look would be achieved if the transition attribute belongs to .nav and not only to .scrolled

@jospoortvliet 