### PR TITLE
Replace support@ with contact form on privacy page

### DIFF
--- a/page-privacy.php
+++ b/page-privacy.php
@@ -1,7 +1,7 @@
 <div class="row">
     <div class="col-md-8 col-md-offset-2">
         <div class="page-header">
-            <h1>Nextcloud GmbH Privacy and Legal Policy - Introduction</h1>
+            <h1>Privacy and Legal Policy - Introduction</h1>
         </div>
         <p>We recognize that privacy is extremely important to all visitors to this website. We do not share any individual information with anybody without your permission.</p>
         <p>We use <a href="http://piwik.org/">Piwik</a> to get information on how our website is used and use <a href="https://www.phplist.com/">phplist</a> to handle our newsletters. From neither will we hand over individual data to anybody else. Any privacy breaches we will disclose as soon as possible.</p>
@@ -95,7 +95,7 @@ Kronenstraße 22A<br/>
 70173 Stuttgart Germany<br/>
 HRB 227086 (AG München)<br/>
 T +49 711 89 66 56 0<br/>
-support@nextcloud.com<br/>
+<a href="/contact">contact form</a><br/>
 </p>
 <p>
 Managing Directors:<br/>


### PR DESCRIPTION
We have done this already for the imprint ... there is another place where this is still appearing 🙀 
Lets remove it there too 😉 

@jospoortvliet @LukasReschke 

cc @karlitschek for legal aspects