### PR TITLE
fixes box page buy button

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
 		buttonDropdown: function (event) {
 			this.variables.buttonDropdownSelector.toggleClass(this.variables.activeClass);
 			this.variables.buttonDropdownContent.toggleClass(this.variables.visibleClass);
-			event.preventDefault();
+// 			event.preventDefault();
 		}
 
 		}


### PR DESCRIPTION
The javascript of the header uses the 'button--dropdown' class, both used for dropdowns like on the box page and in the navigation header. Looks like improving one breaks the other ;-)

This is the same with the #nav class used a lot for the top menu - it was also used in other places, which I had to fix manually. @Espina2 I think you should add to your 'best practices' to not override an existing class but add a class which adds new features or overrides things ;-)

This fixes it but I'm betting it creates a problem somewhere else. But this is javascript so i don't even know how to add a conditional 😿 