### PR TITLE
Update sync.php

### DIFF
--- a/l10n/sync.php
+++ b/l10n/sync.php
@@ -59,7 +59,7 @@ foreach($languages as $language) {
 			curl_close($ch);
 
 			$jsonResponse = json_decode($result, true);
-			if(isset($jsonResponse['completed']) && $jsonResponse['completed'] === '100%') {
+			if(isset($jsonResponse['completed']) && $jsonResponse['completed'] === '100%' && $jsonResponse['reviewed_percentage'] === '100%') {
 				$ch = curl_init();
 				curl_setopt(
 					$ch,


### PR DESCRIPTION
According to https://docs.transifex.com/api/statistics and if I understood what this php code does :see_no_evil:  this change should ensure we only grab 100% translated, 100% reviewed strings.

@LukasReschke could you check my l33t code ruination skills? This should ensure @vaneslie or another reviewer will have to review all texts before they go live.