### PR TITLE
Fix SCSS readme note

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,5 @@ process easy and effective for everyone involved.
 ### Notes
 
 * Please don't commit straight into the master or live branches, these branches should remain as stable as possible, and changes should be discussed amongst the community.
-* After changing any SCSS file, it should be recompiled to CSS before merging. Following options are recommended:
-  * Unix: `sass file.scss:file.css --sourcemap`
-  * Windows: `node-sass file.scss file.css --source-map true`
+* If you are chaning SCSS files during development, following command for automatic compilation is recommended:
+  * `sass --watch [location to scss files]`

--- a/README.md
+++ b/README.md
@@ -33,5 +33,6 @@ process easy and effective for everyone involved.
 ### Notes
 
 * Please don't commit straight into the master or live branches, these branches should remain as stable as possible, and changes should be discussed amongst the community.
-* For every SCSS file, there should be one CSS file compiled with sass (or also node-sass on Win) without any special settings (not nested or compact) and both of these files should be up-to-date when merging them anywhere
-* *.css.map files are ignored by git and are there just for debugging purposes. Should you ever need them, you can use them/create new ones
+* After changing any SCSS file, it should be recompiled to CSS before merging. Following options are recommended:
+  * Unix: `sass file.scss:file.css --sourcemap`
+  * Windows: `node-sass file.scss file.css --source-map true`


### PR DESCRIPTION
As it turns out, I was wrong with my notes aboud compiling SCSS
Truth is, every CSS file currently has sourceMappingURL set at the end of the file, which means, that all SCSS files were originally compiled with sourcemap option turned on.
Not compiling them together with sourcemap would mean deleting sourceMappingURL from the css file, which is unwanted