### PR TITLE
Remove German from FAQ

### DIFF
--- a/page-pricing.php
+++ b/page-pricing.php
@@ -287,7 +287,7 @@
 				<div class="line revealOnScroll"></div>
 				<div class="downarrow revealOnScroll"><a href="#languages" data-toggle="collapse"><h3><?php echo $l->t('In what languages do I get support?<span class="icon-arrow-down">');?></h3></a></div>
 				<div id="languages" class="collapse">
-					<p><?php echo $l->t('We provide support in German and English and other languages through our partners, <a class="hyperlink"  href="#contact">contact us</a> for details.');?></p>
+					<p><?php echo $l->t('We provide support in English with other languages through our partners, <a class="hyperlink"  href="#contact">contact us</a> for details.');?></p>
 				</div>
 				<div class="line revealOnScroll"></div>
 				<div class="downarrow revealOnScroll"><a href="#branding" data-toggle="collapse"><h3><?php echo $l->t('What branding support do I get?<span class="icon-arrow-down">');?></h3></a></div>


### PR DESCRIPTION
We do English support direct, German support via partners (or special deals).

Signed-off-by: Jos Poortvliet <jospoortvliet@gmail.com>