### PR TITLE
make E2e more prominent

### DIFF
--- a/page-homepage.php
+++ b/page-homepage.php
@@ -12,9 +12,9 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-6 toptext ">
-				<a class="announcement" href="https://nextcloud.com/blog/significant-growth-at-nextcloud-conference-brought-150-customers-colleagues-and-friends-together/">
+				<a class="announcement" href="https://nextcloud.com/blog/nextcloud-introducing-native-integrated-end-to-end-encryption/">
 				<span class="type">Event</span>
-				<span class="message"><strong>Nextcloud Conference 2017</strong> brought 150 people together. See our report!</span>
+				<span class="message"><strong>Nextcloud introducing end-to-end encryption</strong> coming in Nextcloud 13. Try our preview!</span>
 				</a>
 				<h1 class="jumbotron--heading-1"><?php echo $l->t('A safe home for all your data');?></h1>
 				<h2 class="jumbotron--lead"><?php echo $l->t('Access, share and protect your files, calendars, contacts, communication & more at home and in your enterprise.');?></h2>

--- a/templates/header-top-navbar.php
+++ b/templates/header-top-navbar.php
@@ -49,6 +49,7 @@ require get_template_directory().'/strings.php';
 					<ul class="nav__links ">
 						<li class="nav__item"><a href="<?php echo home_url('features') ?>"><?php echo $l->t('Overview');?></a></li>
 						<li class="nav__item"><a href="<?php echo home_url('secure') ?>"><?php echo $l->t('Security');?></a></li>
+						<li class="nav__item"><a href="<?php echo home_url('endtoend') ?>"><?php echo $l->t('End-to-end encryption');?></a></li>
 						<li class="nav__item"><a href="<?php echo home_url('sharing') ?>"><?php echo $l->t('Sharing');?></a></li>
 						<li class="nav__item"><a href="<?php echo home_url('clients') ?>"><?php echo $l->t('Clients');?></a></li>
 						<li class="nav__item"><a href="<?php echo home_url('workflow') ?>"><?php echo $l->t('Workflow');?></a></li>
@@ -57,7 +58,6 @@ require get_template_directory().'/strings.php';
 						<li class="nav__item"><a href="<?php echo home_url('collabora') ?>"><?php echo $l->t('Online office');?></a></li>
 						<li class="nav__item"><a href="<?php echo home_url('webrtc') ?>"><?php echo $l->t('Video chat');?></a></li>
 						<li class="nav__item"><a href="<?php echo home_url('outlook') ?>"><?php echo $l->t('Outlook integration');?></a></li>
-						<li class="nav__item"><a href="<?php echo home_url('sharing') ?>"><?php echo $l->t('End-to-end encryption');?></a></li>
 					</ul>
 				</li>
 

--- a/templates/header-top-navbar.php
+++ b/templates/header-top-navbar.php
@@ -57,6 +57,7 @@ require get_template_directory().'/strings.php';
 						<li class="nav__item"><a href="<?php echo home_url('collabora') ?>"><?php echo $l->t('Online office');?></a></li>
 						<li class="nav__item"><a href="<?php echo home_url('webrtc') ?>"><?php echo $l->t('Video chat');?></a></li>
 						<li class="nav__item"><a href="<?php echo home_url('outlook') ?>"><?php echo $l->t('Outlook integration');?></a></li>
+						<li class="nav__item"><a href="<?php echo home_url('sharing') ?>"><?php echo $l->t('End-to-end encryption');?></a></li>
 					</ul>
 				</li>
 


### PR DESCRIPTION
Do we want our end-to-end encryption to show up a lot more prominent? Link to it from our news teaser on the front page and from the menu...
What do you think? I'm not sure about it, but changing our home page link once a month to our 'biggest' announcement (we do them roughly every month anyway) is not so bad. And e2e is big enough for the menu, but the menu is already so big so ... pfff. 

Oh and 'why not wait until 13' -> that makes the menu no shorter (well, only temporary) and we decided to promote it so let's do it right ;-)

@nextcloud/website 

![image](https://user-images.githubusercontent.com/551757/30964218-ae22a0f6-a450-11e7-8c02-3abb5482747b.png)

Thoughts?