### PR TITLE
make education more prominent

### DIFF
--- a/assets/css/pages/enterprise.css
+++ b/assets/css/pages/enterprise.css
@@ -100,6 +100,10 @@
   .section--whitepaper form {
     padding-top: 20px; }
 
+.quote .container {
+  padding-top: 50px !important;
+  margin-top: 180px !important; }
+
 .section--compare {
   padding-bottom: 100px; }
 
@@ -107,5 +111,57 @@
   max-width: 900px;
   margin: 0 auto;
   padding: 60px 0; }
+
+.section--customers {
+  position: relative; }
+  .section--customers .container {
+    padding-top: 8.54297em; }
+    .section--customers .container p {
+      margin-top: 30px; }
+  .section--customers .customer {
+    position: relative; }
+    .section--customers .customer .customer-logo {
+      float: center;
+      height: 400px;
+      position: relative;
+      line-height: 400px;
+      text-align: center;
+      width: 100%;
+      max-width: 60vw;
+      margin-left: auto;
+      margin-right: auto;
+      vertical-align: middle;
+      /*			svg {
+      				vertical-align: middle;
+      				float:none;
+      				width: auto;
+      				height: 400px;
+      				padding-bottom: 100px;
+      			}*/ }
+      .section--customers .customer .customer-logo img {
+        max-width: 90%;
+        vertical-align: middle; }
+      .section--customers .customer .customer-logo .scaling-svg-container {
+        /* 				position: relative; */
+        height: 0;
+        width: 100%;
+        padding: 0;
+        padding-bottom: 100%;
+        /* override this inline for aspect ratio other than square */ }
+      .section--customers .customer .customer-logo svg {
+        position: absolute;
+        height: 100%;
+        width: 100%;
+        /* 		max-width: 50vw; */
+        left: 0;
+        top: 0; }
+      @media (max-width: 991px) {
+        .section--customers .customer .customer-logo {
+          height: 300px;
+          line-height: 300px; } }
+      @media (max-width: 768px) {
+        .section--customers .customer .customer-logo {
+          height: 200px;
+          line-height: 200px; } }
 
 /*# sourceMappingURL=enterprise.css.map */

--- a/assets/css/pages/enterprise.scss
+++ b/assets/css/pages/enterprise.scss
@@ -133,6 +133,13 @@
     margin-bottom: 0px;
 }
 
+.quote {
+	.container {
+	padding-top: 50px !important;
+	margin-top: 180px !important;
+	}
+}
+
 .section--compare {
     padding-bottom: 100px;
 }
@@ -141,4 +148,66 @@
   max-width: 900px;
   margin: 0 auto;
   padding: 60px 0;
+}
+
+.section--customers {
+	position: relative;
+    .container {
+	padding-top: ms(5);
+	p {
+		margin-top: 30px;
+	}
+
+	}
+	.customer {
+		position: relative;
+		.customer-logo {
+			float: center;
+			height: 400px;
+			position: relative;
+			line-height: 400px;
+			text-align:center;
+			width: 100%;
+			max-width: 60vw;
+			margin-left: auto;
+			margin-right: auto;
+			vertical-align: middle;
+			img {
+				max-width: 90%;
+				vertical-align: middle;
+			}
+			.scaling-svg-container {
+/* 				position: relative; */
+				height: 0;
+				width: 100%;
+				padding: 0;
+				padding-bottom: 100%;
+				/* override this inline for aspect ratio other than square */
+				}
+			svg {
+				position: absolute;
+				height: 100%;
+				width: 100%;
+		/* 		max-width: 50vw; */
+				left: 0;
+				top: 0;
+				}
+			@media (max-width: $break-big) {
+				height: 300px;
+				line-height: 300px;
+			}
+			@media (max-width: $break-small) {
+				height: 200px;
+				line-height: 200px;
+			}
+
+/*			svg {
+				vertical-align: middle;
+				float:none;
+				width: auto;
+				height: 400px;
+				padding-bottom: 100px;
+			}*/
+		}
+	}
 }

--- a/page-enterprise.php
+++ b/page-enterprise.php
@@ -41,14 +41,14 @@
 <a name="expertise" id="expertise"></a>
 <section class="section--expertise">
 	<div class="container">
-		<p class="section--intro text-center revealOnScroll">Matter experts</p>
-		<h3 class="section--heading-1 text-center revealOnScroll">Dedicated to your success</h3>
+		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('Matter experts');?></p>
+		<h3 class="section--heading-1 text-center revealOnScroll"><?php echo $l->t('Dedicated to your success');?></h3>
 		<div class="ilustration ilustration__expertise">
 			<?php echo file_get_contents(get_template_directory_uri()."/assets/img/enterprise/ilustration_matterexperts-new.svg"); ?>
 		</div>
 		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('We are dedicated to your success as Nextcloud customer. An analysis of your needs, a pilot customized for your architecture and remote installation support ensures a smooth introduction of Nextcloud in your organization and we will help you scale up to meet growing demand in your organization.');?></p>
 		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('Nextcloud GmbH employs <a class="hyperlink" href="https://nextcloud.com/blog/nextcloud-the-most-active-open-source-file-sync-and-share-project/">9 of the top-ten developers in the Nextcloud Server codebase</a>, making our engineering team by far the most qualified to help you get the most out of your Enterprise File Sync and Share solution.');?></p>
-		<p class="section--intro text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/team">Our team</a></p>
+		<p class="section--intro text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/team"><?php echo $l->t('Our team');?></a></p>
 	</div>
 </section>
 
@@ -64,7 +64,7 @@
 		</div>
 		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('Nextcloud develops its software with a rigorous focus on security through the entire life cycle of the product. Our active and passive security measures are backed by the some of the highest security bug bounties in the open source industry.');?></p>
 		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('As customer you get direct access to our security expertise, with hardening advice and ahead-of-release security issue mitigation and fixes.');?></p>
-		<p class="section--intro text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/secure">Learn about security</a></p>
+		<p class="section--intro text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/secure"><?php echo $l->t('Learn about security');?></a></p>
 	</div>
 </section>
 
@@ -80,7 +80,7 @@
 		</div>
 		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('A Nextcloud support subscription gives you access to enterprise-ready software, updates, and information and support services that span your entire OS and application infrastructure life cycle and architecture. You can count on receiving the latest product versions with the stability and security you need.');?></p>
 		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('Working with data is essential for your business and being forced on the upgrade threadmill is disruptive to your organization. With access to up to 15 years security and stability updates to Nextcloud, we match the lifecycle of your operating system so you can schedule upgrades when it works for you and secure the investments you did in your existing platform.');?></p>
-		<p class="section--intro text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/pricing">See pricing</a></p>
+		<p class="section--intro text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/pricing"><?php echo $l->t('See pricing');?></a></p>
 	</div>
 </section>
 
@@ -96,7 +96,7 @@
 		</div>
 		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('Our unique Nextcloud Global Scale architecture delivers a true globally scalable solution for deployments with hundreds of millions of users, giving unprecedented control over the locality of data and delivering dramatic cost reduction.');?></p>
 		<p class="section--intro text-center revealOnScroll"><?php echo $l->t('Nextcloud Global Scale was designed to lift enterprise collaboration to a new level, overcoming limitations in building large scale file storage, sync & share solutions. Nextcloud Global Scale works by decentralizing data to independent nodes, using several new components to manage the interactions between servers.');?></p>
-		<p class="section--intro text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/globalscale">Learn more</a></p>
+		<p class="section--intro text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/globalscale"><?php echo $l->t('Learn more');?></a></p>
 	</div>
 </section>
 
@@ -122,7 +122,7 @@
                         <div class="g-recaptcha" data-sitekey="<?php echo RECAPTCHA_SITEKEY; ?>"></div>
                     </div>
                     </td>
-                    <input class="mail" type="text" name="email" maxlength="80" placeholder="Enter your email"></label> <input class="button button--blue button--large" type="submit" value=" Get the whitepaper "></p>
+                    <input class="mail" type="text" name="email" maxlength="80" placeholder="<?php echo $l->t('Enter your email');?>"></label> <input class="button button--blue button--large" type="submit" value=" <?php echo $l->t('Get the whitepaper');?> "></p>
                 </form>
             </div>
         </div>
@@ -142,7 +142,7 @@
                         <div class="g-recaptcha" data-sitekey="<?php echo RECAPTCHA_SITEKEY; ?>"></div>
                     </div>
                     </td>
-                    <input class="mail" type="text" name="email" maxlength="80" placeholder="Enter your email"></label> <input class="button button--large" type="submit" value=" Get the case study "></p>
+                    <input class="mail" type="text" name="email" maxlength="80" placeholder="<?php echo $l->t('Enter your email');?>"></label> <input class="button button--large" type="submit" value=" <?php echo $l->t('Get the case study');?> "></p>
                 </form>
             </div>
         </div>

--- a/page-enterprise.php
+++ b/page-enterprise.php
@@ -105,13 +105,12 @@
 
 <section class="section--whitepaper">
     <div class="container">
-        <p class="section--intro text-center revealOnScroll"><?php echo $l->t('Well fitting');?></p>
+        <p class="section--intro text-center revealOnScroll"><?php echo $l->t('What you need');?></p>
         <h2 class="text-center section--heading-1 revealOnScroll"><?php echo $l->t('Nextcloud Enterprise Capabilities');?></h2>
         <div class="row">
             <div class="col-md-6 revealOnScroll">
                 <h3 class=""><?php echo $l->t('Deep integration in your infrastructure');?></h3>
                 <p><?php echo $l->t('Nextcloud offers LDAP/Active Directory, SAML and Kerberos authentication. It accesses data on NFS, (s)FTP, WebDAV, Windows Network Drive, Object Stores like SWIFT and many others.');?></p>
-                <p><?php echo $l->t('Download our Architecture whitepaper or scroll down for a summary of key Nextcloud features.');?></p>
             </div>
         </div>
         <div class="row">
@@ -135,7 +134,7 @@
 	<div class="container revealOnScroll">
         <div class="row">
 			<div class="col-lg-8">
-                <h2 class="revealOnScroll"><?php echo $l->t('How the TU Berlin delivers file sync and share to 22.000 users');?></h2>
+                <h2 class="revealOnScroll"><?php echo $l->t('<span class="avoidwrap">How the TU Berlin delivers</span> <span class="avoidwrap">file sync and share</span> <span class="avoidwrap">to 22.000 users</span>');?></h2>
                 <form name="whitepaper" method="post" action="../tuberlin-whitepapersubmit">
                     <p><label for="email"><?php echo $l->t('Download our free case study: <br /> TU Berlin and 9 other institutions migrate to Nextcloud');?><br>
                     <td colspan="2" style="text-align:center">

--- a/page-enterprise.php
+++ b/page-enterprise.php
@@ -130,6 +130,64 @@
         <img class="responsive" src="<?php bloginfo('template_directory'); ?>/assets/img/whitepapers/architecture-thumbnail-banner.png"/>
     </div>
 </section>
+
+<section class="section--whitepaper quote">
+	<div class="container revealOnScroll">
+        <div class="row">
+			<div class="col-lg-8">
+                <h2 class="revealOnScroll"><?php echo $l->t('How the TU Berlin delivers file sync and share to 22.000 users');?></h2>
+                <form name="whitepaper" method="post" action="../tuberlin-whitepapersubmit">
+                    <p><label for="email"><?php echo $l->t('Download our free case study: <br /> TU Berlin and 9 other institutions migrate to Nextcloud');?><br>
+                    <td colspan="2" style="text-align:center">
+                    <div class="">
+                        <div class="g-recaptcha" data-sitekey="<?php echo RECAPTCHA_SITEKEY; ?>"></div>
+                    </div>
+                    </td>
+                    <input class="mail" type="text" name="email" maxlength="80" placeholder="Enter your email"></label> <input class="button button--large" type="submit" value=" Get the case study "></p>
+                </form>
+            </div>
+        </div>
+        <img class="responsive" src="<?php bloginfo('template_directory'); ?>/assets/img/whitepapers/tub-thumbnail-banner.png"/>
+	</div>
+</section>
+
+
+<section class="section--customers">
+<div class="container">
+    <h2 class="section--heading-1 text-center revealOnScroll"><?php echo $l->t('Nextcloud in Education');?></h2>
+	<div class="row">
+		<div class="col-md-8 col-md-offset-2">
+            <p class="section--paragraph text-center revealOnScroll"><?php echo $l->t('With the Nextcloud Education Edition a unique offering is available providing Moodle integration, Zenodo publishing, SAML authentication, collaboration features and more.');?></p>
+		</div>
+	</div>
+    <div class="row">
+		<div class="col-sm-3 customer">
+            <div class="customer-logo">
+                <div class="scaling-svg-container">
+            <a href="https://nextcloud.com/blog/9-german-educational-and-research-institutions-move-to-nextcloud-as-part-of-tu-berlin-migration-more-coming/"><?php echo file_get_contents(get_template_directory_uri()."/assets/img/customers/tuberlin.svg") ?></a>
+                </div>
+            </div>
+        </div>
+		<div class="col-sm-3 customer">
+            <div class="customer-logo">
+            <a href="https://nextcloud.com/blog/3000-users-at-ucloud4schools-migrated-to-nextcloud-11-by-regio-it/"><img class="" src="<?php echo get_template_directory_uri(); ?>/assets/img/customers/regioit.png" /></a>
+            </div>
+        </div>
+        <div class="col-sm-3 customer">
+            <div class="customer-logo">
+            <a href="https://nextcloud.com/blog/the-danish-research-and-education-network-moves-from-owncloud-to-nextcloud/"><img class="" src="<?php echo get_template_directory_uri(); ?>/assets/img/customers/deic.jpg" /></a>
+            </div>
+        </div>
+        <div class="col-sm-3 customer">
+            <div class="customer-logo">
+            <a href="http://my.engineering.queensu.ca/"><img class="" src="<?php echo get_template_directory_uri(); ?>/assets/img/customers/queens.png" /></a>
+            </div>
+        </div>
+        <div class="text-center revealOnScroll"><a class="button button--blue button--arrow button--large" href="/education">Learn more</a></div>
+    </div>
+</div>
+</section>
+
 <section class="slideshow" id="slideshow">
 	<div class="indicators">
 		<ul class="carousel_dots"></ul>


### PR DESCRIPTION
Creates a new section on the Enterprise page with the TU Berlin case study and a 'nextcloud in Education' section that links to the education page. The 'enterprise capabilities' part was already there.

![image](https://user-images.githubusercontent.com/551757/31310130-d2bdc244-ab92-11e7-9d68-79d5d1a9ffb8.png)


Signed-off-by: Jos Poortvliet <jospoortvliet@gmail.com>