### PR TITLE
Project setup tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ process easy and effective for everyone involved.
   * Select the `content.xml` file from the repository and click upload
   * Select Import
 5. Copy over `config.php.sample` to `config.php` and adjust settings as necessary (defaults will work just fine for local environments)
-6. In `Settings > Reading` assign a static front page of 'homepage'
-7. In `Settings > Permalink` assign the `Post name` setting
 
 ## Development Process
 
@@ -27,8 +25,8 @@ process easy and effective for everyone involved.
 * Setup your local development environment using the instructions above, changing the remote origin url
 * Submit a pull request to master, on github once the feature/bugfix is complete (this is so we can test it on the staging server)
 * After review (usually following one or two thumbs up), a developer will permit the merge into master
-* Code will be pulled onto staging.nextcloud.com for testing (this has to be set up still but the goal is to have this work automatically) 
-* Once the test looks good, staging will be cloned over to nextcloud.com - this is handled by @jospoortvliet or the Nextcloud sysadmins including @LukasReschke 
+* Code will be pulled onto staging.nextcloud.com for testing (this has to be set up still but the goal is to have this work automatically)
+* Once the test looks good, staging will be cloned over to nextcloud.com - this is handled by @jospoortvliet or the Nextcloud sysadmins including @LukasReschke
 
 ### Notes
 

--- a/lib/activation.php
+++ b/lib/activation.php
@@ -67,7 +67,7 @@ function roots_theme_activation_options_render_page() { ?>
                 <option value="false"><?php echo _e('No', 'roots'); ?></option>
               </select>
               <br>
-              <small class="description"><?php printf(__('Create a page called Home and set it to be the static front page', 'roots')); ?></small>
+              <small class="description"><?php printf(__('Create a page called Homepage and set it to be the static front page', 'roots')); ?></small>
             </fieldset>
           </td>
         </tr>
@@ -144,7 +144,7 @@ function roots_theme_activation_action() {
   if ($roots_theme_activation_options['create_front_page'] === 'true') {
     $roots_theme_activation_options['create_front_page'] = false;
 
-    $default_pages = array('Home');
+    $default_pages = array('Homepage');
     $existing_pages = get_pages();
     $temp = array();
 
@@ -165,7 +165,7 @@ function roots_theme_activation_action() {
       $result = wp_insert_post($add_default_pages);
     }
 
-    $home = get_page_by_title('Home');
+    $home = get_page_by_title('Homepage');
     update_option('show_on_front', 'page');
     update_option('page_on_front', $home->ID);
 

--- a/style.css
+++ b/style.css
@@ -1,0 +1,8 @@
+/*
+Theme Name: Next
+Theme URI: https://nextcloud.com
+Description: The custom WordPress theme for nextcloud.com
+Author: Various
+Author URI: https://github.com
+Version:
+*/


### PR DESCRIPTION
I had a couple of minor issues on cloning and setting up the project, so I fixed them. The issues I encountered were:

- WordPress considers the `next` theme to be broken due to the absence of a `style.css` file containing meta data
- On activating the `next` theme in wp-admin and leaving the option to create and set the home page set to "yes", the site's home page was incorrect and needed to be set manually as per step 6 in `README.md`  

I fixed them by:

- Creating a generic `style.css` file and populating it with details that made sense - theme name "next", theme URI "https://nextcloud.com", and so on.
- Adjusting the theme activation function to correctly set `Homepage` as the site home page, instead of `Home`, and removing steps 6 and 7 from `README.md` as they are rendered unnecessary by the theme activation function.

Hopefully, fixing these two small issues will make it a little quicker for new contributors to get up and running.