### PR TITLE
fix syncing of translations

### DIFF
--- a/l10n/sync.php
+++ b/l10n/sync.php
@@ -17,6 +17,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
+ * This file syncs the translated json files into a folder per language,
+ * for example all json pages (like about.json, buy.json etc) into l10n/de
+ * for German.
+ *
+ * Usage: php sync.php <username> <password>
+ *
+ * As username you have to give 'api' and as password the token for Transifex
+ * as it no longer lets you use username/password for the API.
+ *
  */
 
 if(count($argv) !== 3) {
@@ -44,11 +53,14 @@ foreach($languages as $language) {
 				$ch,
 				CURLOPT_URL,
 				sprintf(
-					'http://www.transifex.com/api/2/project/nextcloud-website/resource/%sjson/stats/%s',
+					'https://www.transifex.com/api/2/project/nextcloud-website/resource/%sjson/stats/%s',
 					$pageName,
 					$language
 				)
 			);
+//             echo('resource is '.$pageName.' and language is '.$language."\n");
+//             echo('so the curl URL is: https://www.transifex.com/api/2/project/nextcloud-website/resource/'.$pageName.'json/stats/'.$language."\n");
+
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 			curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
 			curl_setopt($ch, CURLOPT_USERPWD, $userName . ':' . $password);
@@ -57,15 +69,18 @@ foreach($languages as $language) {
 				throw new \Exception('Syncing languages: ' . curl_error($ch));
 			}
 			curl_close($ch);
-
 			$jsonResponse = json_decode($result, true);
+
+// 			echo('translation percentage completed and reviewed for page: '.$pageName.' and language: '.$language.' is: '.$jsonResponse['completed'].' completed'.' and '.$jsonResponse['reviewed_percentage'].' reviewed'."\n".'If both are 100%, we proceed to sync the page.'."\n\n");
+
 			if(isset($jsonResponse['completed']) && $jsonResponse['completed'] === '100%' && $jsonResponse['reviewed_percentage'] === '100%') {
+// 				echo('syncing page: '.$pageName.' for language: '.$language."\n");
 				$ch = curl_init();
 				curl_setopt(
 					$ch,
 					CURLOPT_URL,
 					sprintf(
-						'http://www.transifex.com/api/2/project/nextcloud-website/resource/%sjson/translation/%s',
+						'https://www.transifex.com/api/2/project/nextcloud-website/resource/%sjson/translation/%s',
 						$pageName,
 						$language
 					)
@@ -74,11 +89,18 @@ foreach($languages as $language) {
 				curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
 				curl_setopt($ch, CURLOPT_USERPWD, $userName . ':' . $password);
 				$result = curl_exec($ch);
+// 				echo('We have configured curl now.'."\n");
+
 				if (curl_errno($ch)) {
 					throw new \Exception('Syncing languages: ' . curl_error($ch));
 				}
 				curl_close($ch);
+// 				echo('Dumping the result below.'."\n");
+// 				echo(var_dump($result));
 				$result = json_decode($result, true);
+// 				echo("\n".'Dumping the result after json_decode below.'."\n");
+// 				echo(var_dump($result));
+// 				echo("\n".'Content for page: '.$pageName.' and language: '.$language.' is: '.$result['content']."\n\n");
 				if(isset($result['content'])) {
 					file_put_contents(__DIR__ . '/../l10n/' . $language . '/' . $pageName . '.json', $result['content']);
 				}


### PR DESCRIPTION
The Transifex API changed a little so we had to make two changes:
* No username/password but an API key
* httpS instead of http

There are some echo statements for debugging in the doc & some comments on top I added. I'd like to keep that in so that noobs like me understand & can fix problems 😸 

@mathiasconradt pls approve ;-)

Server is already using this, which is why we got many German language pages now working.