### PR TITLE
[providers] Service Metric does not have a free-plan

### DIFF
--- a/assets/providers.json
+++ b/assets/providers.json
@@ -91,7 +91,7 @@
          "flags":[
             "us"
          ],
-         "freeplans":true,
+         "freeplans":false,
 		 "supports":"both",
          "specializes":[
             "Service Metric offers per user cloud storage to enterprise solutions powered by Nextcloud on fully managed high availability infrastructure in the US."


### PR DESCRIPTION
https://www.servicemetric.com/storage.html <- only a trail, not a free plan 😉 

Was reported over here: https://help.nextcloud.com/t/nextclouds-providers-page/26421