### PR TITLE
Added TLS-option for webchat-links to freenode

### DIFF
--- a/content.xml
+++ b/content.xml
@@ -425,7 +425,7 @@
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key><![CDATA[_menu_item_url]]></wp:meta_key>
-			<wp:meta_value><![CDATA[http://webchat.freenode.net/?channels=owncloud]]></wp:meta_value>
+			<wp:meta_value><![CDATA[https://webchat.freenode.net/?channels=owncloud]]></wp:meta_value>
 		</wp:postmeta>
 	</item>
 	<item>

--- a/page-install.php
+++ b/page-install.php
@@ -68,7 +68,7 @@
 		<p><?php echo $l->t('Discuss using, installing or maintaining Nextcloud in our support channels.');?></p>
 		<ul>
 			<li><?php echo $l->t('<a href="http://help.nextcloud.com" target="_blank" rel="tooltip" title=" Nextcloud User Forums">The Forum</a>');?></li>
-			<li><?php echo $l->t('<a href="irc://#nextcloud@freenode.net" target="_blank" rel="tooltip" title="The Nextcloud IRC Channel">IRC Channel</a> (<a href="http://webchat.freenode.net/?channels=nextcloud" target="_blank"  rel="tooltip" title="Web interface to the Nextcloud IRC Channel">Webchat</a>)');?></li>
+			<li><?php echo $l->t('<a href="irc://#nextcloud@freenode.net" target="_blank" rel="tooltip" title="The Nextcloud IRC Channel">IRC Channel</a> (<a href="https://webchat.freenode.net/?channels=nextcloud" target="_blank"  rel="tooltip" title="Web interface to the Nextcloud IRC Channel">Webchat</a>)');?></li>
 		</ul>
 		<p><?php echo $l->t('These consist of users helping each other. Consider helping out others, too!');?><br />
 		<a href="<?php echo home_url('enterprise') ?>"><?php echo $l->t('Need enterprise support?</a>');?></p>

--- a/page-promote.php
+++ b/page-promote.php
@@ -16,7 +16,7 @@
 </div>
 <p>Nextcloud users and enthusiasts can discuss and share Nextcloud experiences on our Forums, IRC and mailing lists.</p>
       <ul>
-        <li>Join the <a href="https://forum.nextcloud.org">Nextcloud forums</a> and our <a href="irc://#nextcloud@freenode.net" target="_blank">IRC channel</a> (<a href="http://webchat.freenode.net/?channels=nextcloud" target="_blank">Webchat</a>)</li>
+        <li>Join the <a href="https://forum.nextcloud.org">Nextcloud forums</a> and our <a href="irc://#nextcloud@freenode.net" target="_blank">IRC channel</a> (<a href="https://webchat.freenode.net/?channels=nextcloud" target="_blank">Webchat</a>)</li>
         <li>See Nextcloud development questions on <a href="https://stackoverflow.com/questions/tagged/nextcloud">Stack Overflow</a> and <a href="https://community.spiceworks.com/">Spiceworks</a></li>
         <li>Discuss Nextcloud on <a href="https://mailman.nextcloud.org/mailman/listinfo/user">the Nextcloud user mailing list</a></li>
         <li>We meet each other in real life, too, at conferences and meetups. See <a href="/events">our event pages</a> for more information</li>


### PR DESCRIPTION
I just changed the links to the freenode-webchat to https instead of http.
It's still implemented in https://github.com/nextcloud/nextcloud.com/blob/db1041d886a124d2e3a7c0a3b325134aea1b053e/page-box.php#L91


I ignored
https://github.com/nextcloud/nextcloud.com/blob/70440ace0f4bce9b3a680ade7b6fcd222f126bb1/page-install-backup.php#L62
because it's a backup-file.