### PR TITLE
fix: fix jumping description of each job offer when collapsing,

### DIFF
--- a/assets/css/legacy-fixes.css
+++ b/assets/css/legacy-fixes.css
@@ -1,2 +1,1 @@
-html{margin-top:0 !important}footer p{padding:0 !important;padding-top:20px !important}.navbar:not(.scrolled) .btn-primary{border-color:white}@media (max-width: 1200px){.Header-Navigation .navbar .overlay-menu ul .btn-primary a{padding:0 !important}}
-/*# sourceMappingURL=legacy-fixes.css.map */
+html{margin-top:0 !important}footer p{padding:0 !important;padding-top:20px !important}.navbar:not(.scrolled) .btn-primary{border-color:#fff}.collapse.in p:first-child,.collapsing p:first-child{margin:0}@media(max-width: 1200px){.Header-Navigation .navbar .overlay-menu ul .btn-primary a{padding:0 !important}}/*# sourceMappingURL=legacy-fixes.css.map */

--- a/assets/css/legacy-fixes.scss
+++ b/assets/css/legacy-fixes.scss
@@ -17,6 +17,11 @@ footer p {
   border-color: white;
 }
 
+.collapse.in p:first-child,
+.collapsing p:first-child {
+  margin: 0;
+}
+
 .Header-Navigation .navbar .overlay-menu ul .btn-primary a {
 /*   width: 169px; */
 /*   height: 52px; */


### PR DESCRIPTION
I came around [this](https://github.com/nextcloud/nextcloud.com/issues/493) and thought I fix it quickly :)

**What did I do ?**
I added the following styles to `legacy-fixes.scss` since the bug was located inside the `collapse`-class:
```scss
.collapse.in p:first-child,
.collapsing p:first-child {
  margin: 0;
}
``` 

**The Problem**
The class `collapse` is replaced with `collapsing` this in combination with the margin on the p-tag caused the bug.

fixes https://github.com/nextcloud/nextcloud.com#493