### PR TITLE
Make contact form more compliant with RFC-5322

### DIFF
--- a/page-contactsubmit.php
+++ b/page-contactsubmit.php
@@ -64,7 +64,7 @@ if(isset($_POST['email'])) {
     }
 
 
-    $email_exp = '/^[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,10}$/';
+    $email_exp = '/^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,10}$/';
   if(!preg_match($email_exp,$email_from)) {
     $error_message .= 'The email address you entered does not appear to be valid.<br />';
   }


### PR DESCRIPTION
* currently max+private@example.com and max+business@example.com gets rejected
* `+` in email address is allowed based on RFC-5322
* `+` in email address is used by Google (Gmail) as alias

Based on feedback from @mathiasconradt and a user :)