### PR TITLE
Fix style of changelog page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -9996,6 +9996,10 @@ ul {
 li {
   margin-top: 15px; }
 
+body.changelog .content ul li {
+  margin-top: 0;
+  list-style: circle;
+}
 /* Images */
 .alignright {
   float: right;

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -722,6 +722,11 @@ ul {
 li {
   margin-top: 15px; }
 
+body.changelog .content ul li {
+  margin-top: 0;
+  list-style: circle;
+}
+
 /* Images */
 .alignright {
   float: right;


### PR DESCRIPTION
Before:

<img width="1370" alt="bildschirmfoto 2018-10-12 um 09 15 42" src="https://user-images.githubusercontent.com/245432/46853874-a5fd5e00-cdff-11e8-8be1-f6f988d7ad4f.png">

After:

<img width="1370" alt="bildschirmfoto 2018-10-12 um 09 17 22" src="https://user-images.githubusercontent.com/245432/46853883-abf33f00-cdff-11e8-92a6-78daaf0e6e32.png">
