### PR TITLE
Fix list layout of advisory page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -10280,6 +10280,10 @@ li {
 body.changelog .content ul li {
   margin-top: 0;
   list-style: circle; }
+body.advisories .content ul li {
+  margin-top: 0;
+  list-style-type: initial;
+  margin-left: 5px; }
 
 /* Images */
 .alignright {

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -726,6 +726,11 @@ body.changelog .content ul li {
   margin-top: 0;
   list-style: circle;
 }
+body.advisories .content ul li {
+  margin-top: 0;
+  list-style-type: initial;
+  margin-left: 5px;
+}
 
 /* Images */
 .alignright {

--- a/page-advisories.php
+++ b/page-advisories.php
@@ -15,7 +15,7 @@
 <section class="content">
 <div class="container">
 <div class="row page-content-header">
-	<div class="col-md-5 col-md-offset-2">
+	<div class="col-md-3 col-md-offset-9">
 		<form role="form" action="/security/advisory/" method="get">
 			<input name="id" type="text" class="form-control" placeholder="Advisory identifier">
 			<button type="submit" class="btn btn-default">Go</button>


### PR DESCRIPTION
Was screwed up by removing bullets from list entries. Same as #971


See https://github.com/nextcloud/security-advisories/pull/3

Before:
![bildschirmfoto 2018-10-25 um 15 44 53](https://user-images.githubusercontent.com/245432/47504768-3068a780-d86d-11e8-9a4f-1d37fad8aeca.png)

After:

![bildschirmfoto 2018-10-25 um 15 44 47](https://user-images.githubusercontent.com/245432/47504767-3068a780-d86d-11e8-9478-96a3c98cebd2.png)
