### PR TITLE
Direct link to server-download options

### DIFF
--- a/templates/header-top-navbar.php
+++ b/templates/header-top-navbar.php
@@ -108,7 +108,7 @@ require get_template_directory() . '/strings.php';
                 <li class="nav__section"><a class="nav__label"><?php echo $l->t('Get Nextcloud'); ?></a>
                     <ul class="nav__links ">
                         <li class="nav__item">
-                            <a href="<?php echo home_url('install'); ?>">
+                            <a href="<?php echo home_url('install/#instructions-server'); ?>">
                                 <div class="nav__logo">
                                     <?php echo file_get_contents(get_template_directory()."/assets/img/icons/download.svg");?>
                                 </div>


### PR DESCRIPTION
All other links (Devices, Clients, ...) are linked elsewhere in the nav-bar now :)
Let the legacy **/install/**-page die slowly 🙈😈💀

Signed-off-by: Marius Blüm <marius@lineone.io>