### PR TITLE
Fix "You have javascript disabled" false positive

### DIFF
--- a/page-clients.php
+++ b/page-clients.php
@@ -22,6 +22,7 @@
 		</div>
 	</div>
 </div>
+
 <section class="section--intro">
 	<div class="container">
 		<div class="row">
@@ -35,95 +36,96 @@
 	</div>
 </section>
 
-
 <section class="section--desktop" id="desktop">
-<div class="container">
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2 revealOnScroll feature--block">
-			<h2 class="text-center"><?php echo $l->t('Sync and collaborate on your desktop or laptop');?></h2>
-			<p class="section--paragraph text-center"><?php echo $l->t('The Nextcloud desktop client keeps photos and documents always up to date, enabling you to work like you always did.');?></p>
-        </div>
-    </div>
-    <div class="row">
-		<div class="col-md-6 revealOnScroll">
-			<img class="img-responsive" src="<?php echo get_template_directory_uri(); ?>/assets/img/clients/desktop/linux.png" alt="in action" >
-		</div>
-		<div class="col-md-6 revealOnScroll feature--block">
-			<p class="section--paragraph"><?php echo $l->t('Any file you add, modify or delete in the synced folders on your desktop or laptop will show up, change or disappear on the server and all other connected devices.');?></p>
-			<p class="section--paragraph"><?php echo $l->t('Sync one or more folders locally with folders on the server and pick what folders you don\t need.');?></p>
-			<p class="section--paragraph"><?php echo $l->t('Right-click a file in your file manager and easily share it with other users, a public link or by email.');?></p>
-			<p class="section--paragraph"><?php echo $l->t('Get notified of activities and events, like an incoming call, a comment on a file or a new folder that is shared with you.');?></p>
-			<a href="<?php echo home_url('install/#install-clients') ?>" class="button button--blue button--arrow button--large"><?php echo $l->t('Get the desktop client');?></a>
-		</div>
-	</div>
-</section>
-<section class="section--desktop-features">
-<div class="container-fluid quote">
     <div class="container">
-        <h2 class="text-center revealOnScroll"><?php echo $l->t('Desktop client features');?></h2>
         <div class="row">
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('Select any number of local folders to keep in sync with specified remote folders');?></li>
-                <li><?php echo $l->t('Exempt any number of subfolders in a synced folder from being synced');?></li>
-                <li><?php echo $l->t('Optional warning in case a very big new subfolder was added');?></li>
-                <li><?php echo $l->t('Easily pause and resume syncing');?></li>
-                </ul></p>
+            <div class="col-md-8 col-md-offset-2 revealOnScroll feature--block">
+                <h2 class="text-center"><?php echo $l->t('Sync and collaborate on your desktop or laptop');?></h2>
+                <p class="section--paragraph text-center"><?php echo $l->t('The Nextcloud desktop client keeps photos and documents always up to date, enabling you to work like you always did.');?></p>
             </div>
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('Receive notifications of server events like a new share or audio/video call');?></li>
-                <li><?php echo $l->t('Use the activity feed to track what happens on the server');?></li>
-                <li><?php echo $l->t('Immediately reply to notifications to join a call or accept a share');?></li>
-                <li><?php echo $l->t('Protect your files with client side,');?> <a class="hyperlink" href="<?php echo home_url('endtoend') ?>"><?php echo $l->t('End-to-end encryption</a> (version 2.5.0+)');?></li>
-                </ul></p>
+        </div>
+        <div class="row">
+            <div class="col-md-6 revealOnScroll">
+                <img class="img-responsive" src="<?php echo get_template_directory_uri(); ?>/assets/img/clients/desktop/linux.png" alt="in action" >
             </div>
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('Easily configure a proxy or set bandwidth throttling');?></li>
-                <li><?php echo $l->t('Enjoy convenient file manager integration for easy sharing');?></li>
-                <li><?php echo $l->t('Branding support for ');?><a class="hyperlink" href="<?php echo home_url('enterprise') ?>"><?php echo $l->t('enterprise customers');?></a></li>
-                <li><?php echo $l->t('Set up multiple accounts');?></li>
-                </ul></p>
+            <div class="col-md-6 revealOnScroll feature--block">
+                <p class="section--paragraph"><?php echo $l->t('Any file you add, modify or delete in the synced folders on your desktop or laptop will show up, change or disappear on the server and all other connected devices.');?></p>
+                <p class="section--paragraph"><?php echo $l->t('Sync one or more folders locally with folders on the server and pick what folders you don\t need.');?></p>
+                <p class="section--paragraph"><?php echo $l->t('Right-click a file in your file manager and easily share it with other users, a public link or by email.');?></p>
+                <p class="section--paragraph"><?php echo $l->t('Get notified of activities and events, like an incoming call, a comment on a file or a new folder that is shared with you.');?></p>
+                <a href="<?php echo home_url('install/#install-clients') ?>" class="button button--blue button--arrow button--large"><?php echo $l->t('Get the desktop client');?></a>
             </div>
         </div>
     </div>
-</div>
-<section class="section--desktop-screenshots">
-<div class="container">
-    <h2 class="text-center revealOnScroll"><?php echo $l->t('Desktop client in action');?></h2>
-    <div class="row">
-        <div class="col-md-4">
-            <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/share-dialog.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/share-dialog.png" alt="" class="img-responsive" /></a>
-            Easy to use sharing dialog
-        </div>
-        <div class="col-md-4">
-            <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/share-dialog-options.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/share-dialog-options.png" alt="" class="img-responsive" /></a>
-            Share dialog options only show when needed
-        </div>
-        <div class="col-md-4">
-            <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/context-menu.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/context-menu.png" alt="" class="img-responsive" /></a>
-            Open Nextcloud apps from the context menu
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-4">
-            <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/space-used.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/space-used.png" alt="" class="img-responsive" /></a>
-            See how much storage you have left
-        </div>
-        <div class="col-md-4">
-            <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/edit-ignored-files.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/edit-ignored-files.png" alt="" class="img-responsive" /></a>
-            List which files should not be synced
-        </div>
-        <div class="col-md-4">
-        <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/separate-activities.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/separate-activities.png" alt="" class="img-responsive" /></a>
-        View and respond to activities and notifications
-        </div>
-    </div>
-</div>
 </section>
 
+<section class="section--desktop-features">
+    <div class="container-fluid quote">
+        <div class="container">
+            <h2 class="text-center revealOnScroll"><?php echo $l->t('Desktop client features');?></h2>
+            <div class="row">
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('Select any number of local folders to keep in sync with specified remote folders');?></li>
+                    <li><?php echo $l->t('Exempt any number of subfolders in a synced folder from being synced');?></li>
+                    <li><?php echo $l->t('Optional warning in case a very big new subfolder was added');?></li>
+                    <li><?php echo $l->t('Easily pause and resume syncing');?></li>
+                    </ul></p>
+                </div>
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('Receive notifications of server events like a new share or audio/video call');?></li>
+                    <li><?php echo $l->t('Use the activity feed to track what happens on the server');?></li>
+                    <li><?php echo $l->t('Immediately reply to notifications to join a call or accept a share');?></li>
+                    <li><?php echo $l->t('Protect your files with client side,');?> <a class="hyperlink" href="<?php echo home_url('endtoend') ?>"><?php echo $l->t('End-to-end encryption</a> (version 2.5.0+)');?></li>
+                    </ul></p>
+                </div>
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('Easily configure a proxy or set bandwidth throttling');?></li>
+                    <li><?php echo $l->t('Enjoy convenient file manager integration for easy sharing');?></li>
+                    <li><?php echo $l->t('Branding support for ');?><a class="hyperlink" href="<?php echo home_url('enterprise') ?>"><?php echo $l->t('enterprise customers');?></a></li>
+                    <li><?php echo $l->t('Set up multiple accounts');?></li>
+                    </ul></p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
+<section class="section--desktop-screenshots">
+    <div class="container">
+        <h2 class="text-center revealOnScroll"><?php echo $l->t('Desktop client in action');?></h2>
+        <div class="row">
+            <div class="col-md-4">
+                <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/share-dialog.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/share-dialog.png" alt="" class="img-responsive" /></a>
+                Easy to use sharing dialog
+            </div>
+            <div class="col-md-4">
+                <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/share-dialog-options.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/share-dialog-options.png" alt="" class="img-responsive" /></a>
+                Share dialog options only show when needed
+            </div>
+            <div class="col-md-4">
+                <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/context-menu.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/context-menu.png" alt="" class="img-responsive" /></a>
+                Open Nextcloud apps from the context menu
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-4">
+                <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/space-used.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/space-used.png" alt="" class="img-responsive" /></a>
+                See how much storage you have left
+            </div>
+            <div class="col-md-4">
+                <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/edit-ignored-files.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/edit-ignored-files.png" alt="" class="img-responsive" /></a>
+                List which files should not be synced
+            </div>
+            <div class="col-md-4">
+            <a href="<?php echo get_template_directory_uri(); ?>/assets/img/features/separate-activities.png"><img src="<?php echo get_template_directory_uri(); ?>/assets/img/features/separate-activities.png" alt="" class="img-responsive" /></a>
+            View and respond to activities and notifications
+            </div>
+        </div>
+    </div>
+</section>
 
 <section class="section--mobile" id="mobileid">
 	<div class="container">
@@ -147,6 +149,7 @@
                 <img class="img-responsive" src="<?php echo get_template_directory_uri(); ?>/assets/img/clients/mobile/android2.png" alt="in action" >
             </div>
         </div>
+    </div>
 </section>
 
 <section class="section--ios" id="iosid">
@@ -194,42 +197,41 @@
 </section>
 
 <section class="section--ios-features">
-<div class="container-fluid quote">
-    <div class="container">
-        <h2 class="text-center revealOnScroll"><?php echo $l->t('iOS client features');?></h2>
-        <div class="row">
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('Display documents, photos, videos, audio files, as a list or thumbnails, sorted as you like.');?></li>
-                <li><?php echo $l->t('Edit files on the phone built in or using other apps installed on your iPhone or iPad.');?></li>
-                <li><?php echo $l->t('Add, rename, copy, move and delete files and folders');?></li>
-                <li><?php echo $l->t('Keep your favorite files available offline');?></li>
-                </ul></p>
-            </div>
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('Share files with others');?></li>
-                <li><?php echo $l->t('Client-side,');?> <a class="hyperlink" href="<?php echo home_url('endtoend') ?>"><?php echo $l->t('End-to-end encryption');?></a></li>
-                <li><?php echo $l->t('Local and server-side search');?></li>
-                <li><?php echo $l->t('Support for server notifications and file activity feed');?></li>
-                <li><?php echo $l->t('3D Touch peek&pop and homescreen quick actions');?></li>
-                <li><?php echo $l->t('Scan-to-PDF with rotation and quality level control');?></li>
-                </ul></p>
-            </div>
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('Multi-account support');?></li>
-                <li><?php echo $l->t('Adjusts to Nextcloud server theming preferences');?></li>
-                <li><?php echo $l->t('Auto-upload of photos and videos with custom file naming and folder sorting, wifi-only upload and HEIC support');?></li>
-                <li><?php echo $l->t('iOS 11 Files Integration');?></li>
-                <li><?php echo $l->t('Trash and versions integration');?></li>
-                </ul></p>
+    <div class="container-fluid quote">
+        <div class="container">
+            <h2 class="text-center revealOnScroll"><?php echo $l->t('iOS client features');?></h2>
+            <div class="row">
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('Display documents, photos, videos, audio files, as a list or thumbnails, sorted as you like.');?></li>
+                    <li><?php echo $l->t('Edit files on the phone built in or using other apps installed on your iPhone or iPad.');?></li>
+                    <li><?php echo $l->t('Add, rename, copy, move and delete files and folders');?></li>
+                    <li><?php echo $l->t('Keep your favorite files available offline');?></li>
+                    </ul></p>
+                </div>
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('Share files with others');?></li>
+                    <li><?php echo $l->t('Client-side,');?> <a class="hyperlink" href="<?php echo home_url('endtoend') ?>"><?php echo $l->t('End-to-end encryption');?></a></li>
+                    <li><?php echo $l->t('Local and server-side search');?></li>
+                    <li><?php echo $l->t('Support for server notifications and file activity feed');?></li>
+                    <li><?php echo $l->t('3D Touch peek&pop and homescreen quick actions');?></li>
+                    <li><?php echo $l->t('Scan-to-PDF with rotation and quality level control');?></li>
+                    </ul></p>
+                </div>
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('Multi-account support');?></li>
+                    <li><?php echo $l->t('Adjusts to Nextcloud server theming preferences');?></li>
+                    <li><?php echo $l->t('Auto-upload of photos and videos with custom file naming and folder sorting, wifi-only upload and HEIC support');?></li>
+                    <li><?php echo $l->t('iOS 11 Files Integration');?></li>
+                    <li><?php echo $l->t('Trash and versions integration');?></li>
+                    </ul></p>
+                </div>
             </div>
         </div>
     </div>
-</div>
 </section>
-
 
 <section class="section--android" id="androidid">
 	<div class="container">
@@ -257,47 +259,46 @@
 </section>
 
 <section class="section--android-features">
-<div class="container-fluid quote">
-    <div class="container">
-        <h2 class="text-center revealOnScroll"><?php echo $l->t('Android app features');?></h2>
-        <div class="row">
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('Display documents, photos, videos, audio files, as a list or thumbnails, sorted as you like.');?></li>
-                <li><?php echo $l->t('Stream media files (needs at least Nextcloud 14)');?></li>
-                <li><?php echo $l->t('Edit files on the phone built in or using other apps installed on your Android device.');?></li>
-                <li><?php echo $l->t('Local and server-side search');?></li>
-                <li><?php echo $l->t('Add, rename, copy, move and delete files and folders');?></li>
-                <li><?php echo $l->t('Keep your favorite files available offline');?></li>
-                <li><?php echo $l->t('Restore deleted files (needs at least Nextcloud 14)');?></li>
-                </ul></p>
-            </div>
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('Share files with others');?></li>
-                <li><?php echo $l->t('Shared files view');?></li>
-                <li><?php echo $l->t('Simple contacts backup & restore');?></li>
-                <li><?php echo $l->t('Auto-configuration of Contacts and Calendar integration through DAVDroid');?></li>
-                <li><?php echo $l->t('Client-side,');?> <a class="hyperlink" href="<?php echo home_url('endtoend') ?>"><?php echo $l->t('End-to-end encryption');?></a></li>
-                <li><?php echo $l->t('Support for server push notifications and file activity feed');?></li>
-                <li><?php echo $l->t('View and reply to comments on files (needs at least Nextcloud 14)');?></li>
-                </ul></p>
-            </div>
-            <div class="col-sm-4 revealOnScroll">
-                <p class="section--paragraph"><ul>
-                <li><?php echo $l->t('TalkBack screenreader support');?></li>
-                <li><?php echo $l->t('Multi-account support');?></li>
-                <li><?php echo $l->t('Fingerprint locking');?></li>
-                <li><?php echo $l->t('Adjusts to Nextcloud server theming preferences');?></li>
-                <li><?php echo $l->t('Auto-upload of any type of data including photos and videos with custom file naming and folder sorting, wifi-only upload, differential handling of photos and videos');?></li>
-                <li><?php echo $l->t('monitor any number of folders for any file type so you can upload Whatsapp images, documents and anything else');?></li>
-                </ul></p>
+    <div class="container-fluid quote">
+        <div class="container">
+            <h2 class="text-center revealOnScroll"><?php echo $l->t('Android app features');?></h2>
+            <div class="row">
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('Display documents, photos, videos, audio files, as a list or thumbnails, sorted as you like.');?></li>
+                    <li><?php echo $l->t('Stream media files (needs at least Nextcloud 14)');?></li>
+                    <li><?php echo $l->t('Edit files on the phone built in or using other apps installed on your Android device.');?></li>
+                    <li><?php echo $l->t('Local and server-side search');?></li>
+                    <li><?php echo $l->t('Add, rename, copy, move and delete files and folders');?></li>
+                    <li><?php echo $l->t('Keep your favorite files available offline');?></li>
+                    <li><?php echo $l->t('Restore deleted files (needs at least Nextcloud 14)');?></li>
+                    </ul></p>
+                </div>
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('Share files with others');?></li>
+                    <li><?php echo $l->t('Shared files view');?></li>
+                    <li><?php echo $l->t('Simple contacts backup & restore');?></li>
+                    <li><?php echo $l->t('Auto-configuration of Contacts and Calendar integration through DAVDroid');?></li>
+                    <li><?php echo $l->t('Client-side,');?> <a class="hyperlink" href="<?php echo home_url('endtoend') ?>"><?php echo $l->t('End-to-end encryption');?></a></li>
+                    <li><?php echo $l->t('Support for server push notifications and file activity feed');?></li>
+                    <li><?php echo $l->t('View and reply to comments on files (needs at least Nextcloud 14)');?></li>
+                    </ul></p>
+                </div>
+                <div class="col-sm-4 revealOnScroll">
+                    <p class="section--paragraph"><ul>
+                    <li><?php echo $l->t('TalkBack screenreader support');?></li>
+                    <li><?php echo $l->t('Multi-account support');?></li>
+                    <li><?php echo $l->t('Fingerprint locking');?></li>
+                    <li><?php echo $l->t('Adjusts to Nextcloud server theming preferences');?></li>
+                    <li><?php echo $l->t('Auto-upload of any type of data including photos and videos with custom file naming and folder sorting, wifi-only upload, differential handling of photos and videos');?></li>
+                    <li><?php echo $l->t('monitor any number of folders for any file type so you can upload Whatsapp images, documents and anything else');?></li>
+                    </ul></p>
+                </div>
             </div>
         </div>
     </div>
-</div>
 </section>
-
 
 <section class="section--intro">
 	<div class="container">


### PR DESCRIPTION
:information_source: Easier to review with the [`?w=1`](https://github.com/nextcloud/nextcloud.com/pull/1002/files?w=1) flag.

---

Adds a missing `</section>` closing tag in page-clients.php.

This triggered "You have javascript disabled" false positive due to
`.alert--no-js` not being a direct child of `<body>` [0].

Note: this JS detection script should probably be more robust as this
is not the first time this issue occurs [1].

Also, adds two missing `</div>` tags and indents `<section>` children in
page-clients.php to make future missing closing tags more visible.

[0]: https://nextcloud.com/clients/
[1]: https://github.com/nextcloud/nextcloud.com/issues/931