### PR TITLE
Small layout fix on team page

### DIFF
--- a/page-team.php
+++ b/page-team.php
@@ -353,7 +353,7 @@
 				<img class="img-responsive img-circle teamimg" alt="photo" src="<?php bloginfo('template_directory'); ?>/assets/img/people/dirk.jpg" />
 				<h2 class="teamname">Dirk Farin</h2>
 				<div class="teammeta">
-					<h3 class="teamtitle">Research Scientist and Software Engineer</h3>
+					<h3 class="teamtitle">Research Scientist / Software Engineer</h3>
 					<h4 class="teamexpertise">WebRTC, Codecs, Spreed.ME</h4>
 					<h4 class="teamlocation">lives in Stuttgart, Germany</h4>
 					<p class="teamsocial"><a href="http://www.dirk-farin.net/"><i class="fa-rss fa"></i></a> <a href="https://github.com/farindk"><i class="fa-github fa"></i></a> <!--<a href="https://twitter.com/rullzer"><i class="fa-twitter fa"></i></a>--> </p>


### PR DESCRIPTION
**Before:**
<img width="1417" alt="bildschirmfoto 2018-11-29 um 11 37 16" src="https://user-images.githubusercontent.com/19711361/49216466-68fb2400-f3cb-11e8-9951-4d8ce11f5722.png">

**After:**
<img width="1415" alt="bildschirmfoto 2018-11-29 um 11 37 33" src="https://user-images.githubusercontent.com/19711361/49216470-6f899b80-f3cb-11e8-831d-f2039ee85944.png">

Signed-off-by: Marius Blüm <marius@lineone.io>