### PR TITLE
add short business model explainer to signup page

### DIFF
--- a/page-signup.php
+++ b/page-signup.php
@@ -111,7 +111,7 @@ $coreApps = ['files', 'calendar', 'contacts', 'spreed', 'mail', 'tasks', 'notes'
             <div class="text-center">
             <a href="<?php echo home_url('privacy') ?>" target="_blank" class="button button--blue button--arrow button--large"><?php echo $l->t('Our privacy policy'); ?></a>
             <p class="section--paragraph text-center"><?php echo $l->t('If there are any issues with your account, please note that we do NOT record any of your information on our side so we can not help you. Please contact the provider you signed up with.'); ?></p>
-            <p class="section--paragraph text-center"><?php echo $l->t('* free services are, of course, paid somewhere, by someone. Often with your data! Our providers all give a free 2-5GB storage shared account but offer larger storage and more options like a dedicated setup for a fee, which funds the free accounts. Consider paying for your account, it helps them provide this service!'); ?></p>
+            <p class="section--paragraph text-center"><?php echo $l->t('* free services are of course paid somewhere by someone. The listed Nextcloud providers all give a free account with 2 to 5 GB storage but offer larger storage and more options like a dedicated setup for a fee, which funds the free accounts. Consider paying for your account, it helps them provide this service!'); ?></p>
             </div>
         </div>
     </div>

--- a/page-signup.php
+++ b/page-signup.php
@@ -81,7 +81,7 @@ $coreApps = ['files', 'calendar', 'contacts', 'spreed', 'mail', 'tasks', 'notes'
 			<div class="col-md-6 topheader">
 				<h1><?php echo $l->t('Your choice');?></h1>
 				<h2><?php echo $l->t('To help you decide where to store your data, Nextcloud maintains a list of preferred providers.');?></h2>
-                <h2><?php echo $l->t('Sign up now and get a free storage account!');?></h2>
+                <h2><?php echo $l->t('Sign up now and get a free* storage account!');?></h2>
 			</div>
 		</div>
 	</div>
@@ -111,6 +111,7 @@ $coreApps = ['files', 'calendar', 'contacts', 'spreed', 'mail', 'tasks', 'notes'
             <div class="text-center">
             <a href="<?php echo home_url('privacy') ?>" target="_blank" class="button button--blue button--arrow button--large"><?php echo $l->t('Our privacy policy'); ?></a>
             <p class="section--paragraph text-center"><?php echo $l->t('If there are any issues with your account, please note that we do NOT record any of your information on our side so we can not help you. Please contact the provider you signed up with.'); ?></p>
+            <p class="section--paragraph text-center"><?php echo $l->t('* free services are, of course, paid somewhere, by someone. Often with your data! Our providers all give a free 2-5GB storage shared account but offer larger storage and more options like a dedicated setup for a fee, which funds the free accounts. Consider paying for your account, it helps them provide this service!'); ?></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
It was pointed out to me that we offer a 'free' service here, but don't really explain who pays and how. After all, our competition tends to monetize your private data to enable them to provide a service for free. I added a short explainer. Thoughts?

Signed-off-by: Jos Poortvliet <jospoortvliet@gmail.com>