### PR TITLE
Improve wording of sub-headline on frontpage

### DIFF
--- a/page-homepage.php
+++ b/page-homepage.php
@@ -18,7 +18,7 @@
 				<?php echo file_get_contents(get_template_directory_uri()."/assets/img/next.svg"); ?>
 				</a>
 				<h1 class="jumbotron--heading-1"><?php echo $l->t('Protecting your data');?></h1>
-				<h2 class="jumbotron--lead"><?php echo $l->t('The self-hosted platform that makes you productive without losing control');?></h2>
+				<h2 class="jumbotron--lead"><?php echo $l->t('The self-hosted productivity platform that keeps you in control');?></h2>
 				<a class="button button--large button--arrow button--white" href="<?php echo home_url('install') ?>" role="button" id="get-nextcloud-button"><?php echo $l->t('Get Nextcloud');?></a><br>
 				<a class="button button--large button--arrow--down button--blue" href="#why-nextcloud" role="button" id="get-nextcloud-button"><?php echo $l->t('Learn more');?></a>
 			</div>

--- a/page-homepage.php
+++ b/page-homepage.php
@@ -18,7 +18,7 @@
 				<?php echo file_get_contents(get_template_directory_uri()."/assets/img/next.svg"); ?>
 				</a>
 				<h1 class="jumbotron--heading-1"><?php echo $l->t('Protecting your data');?></h1>
-				<h2 class="jumbotron--lead"><?php echo $l->t('Building self-hosted products that allow you to be productive without losing control');?></h2>
+				<h2 class="jumbotron--lead"><?php echo $l->t('The self-hosted platform that makes you productive without losing control');?></h2>
 				<a class="button button--large button--arrow button--white" href="<?php echo home_url('install') ?>" role="button" id="get-nextcloud-button"><?php echo $l->t('Get Nextcloud');?></a><br>
 				<a class="button button--large button--arrow--down button--blue" href="#why-nextcloud" role="button" id="get-nextcloud-button"><?php echo $l->t('Learn more');?></a>
 			</div>


### PR DESCRIPTION
The subheadline is a bit bumpy:

> Building self-hosted products that allow you to be productive without losing control

"products" and "productive" clash, and why the "building"? We should be talking about what the product does for people, not what we do?

E.g.:

> The self-hosted platform that makes you productive without losing control


What do you think @jospoortvliet @shironextcloud 