### PR TITLE
Fix Simple Sign up layout on mobile

### DIFF
--- a/assets/css/pages/signup.scss
+++ b/assets/css/pages/signup.scss
@@ -66,7 +66,7 @@ section {
 
 @media (max-width: 768px) {
     #register {
-        margin-top: -500px;
+        margin-top: -380px;
     }
     .background .topheader {
         top: 0px;


### PR DESCRIPTION
Fixes the overlap cc @jospoortvliet @skjnldsv. Total hack but well

@skjnldsv @jospoortvliet can we get rid of the `revealOnLoad`? Also there’s a horizontal scrollbar and content is squished to the right?

## Before
![simple signup before](https://user-images.githubusercontent.com/925062/68318790-96614f00-00bd-11ea-9ec4-731823140d9d.png)

## After
![simple signup fixed](https://user-images.githubusercontent.com/925062/68318791-96614f00-00bd-11ea-9ad6-3feacad8cae4.png)
