### PR TITLE
Fix broken bounty program link in athome.php

### DIFF
--- a/page-athome.php
+++ b/page-athome.php
@@ -145,7 +145,7 @@
 			<h3 class="section--paragraph__title"><?php echo $l->t('Security first');?></h3>
 			<p class="section--paragraph"><?php echo $l->t('We are deeply committed to protecting the safety of your data and we\'re certain that Nextcloud offers the best security in the self hosted file sync and share world, because:');?></p>
 			<p class="section--paragraph"><?php echo $l->t('<i class="fa-key fa"></i> we follow industry best practices around security (aligned to <a class="hyperlink" href="https://en.wikipedia.org/wiki/ISO/IEC_27001:2013">ISO27001</a>)');?></p>
-			<p class="section--paragraph"><?php echo $l->t('<i class="fa-key fa"></i> we offer some of the <a class="hyperlink" href="https://nextcloud.com/introducing-the-nextcloud-bug-bounty-program/" target="_blank">highest open source security bug bounties</a>');?></p>
+			<p class="section--paragraph"><?php echo $l->t('<i class="fa-key fa"></i> we offer some of the <a class="hyperlink" href="https://nextcloud.com/blog/introducing-the-nextcloud-bug-bounty-program/" target="_blank">highest open source security bug bounties</a>');?></p>
 			<p class="section--paragraph"><?php echo $l->t('');?></p>
 			<p class="section--paragraph"><?php echo $l->t('<i class="fa-key fa"></i> we integrate unique in-transit, server-side and client-side end-to-end encryption technologies.');?></p>
 			<p class="section--paragraph"><?php echo $l->t('');?></p>


### PR DESCRIPTION
Insert "blog/" to fix a broken link to the bounty program blog post in the athome page.