### PR TITLE
update design of devices page

### DIFF
--- a/assets/css/pages/devices.css
+++ b/assets/css/pages/devices.css
@@ -42,11 +42,28 @@ section {
   section .section--paragraph__title {
     padding: 0; }
 
-.feature--block {
+.section--devices .feature--block {
   padding-top: 60px; }
-
-.row {
+.section--devices .row {
   padding-top: 60px; }
+.section--devices .col-md-4 {
+  padding: 20px; }
+.section--devices .block-container {
+  height: 800px;
+  overflow-y: auto;
+  box-shadow: 0 0 1px rgba(39, 44, 49, 0.1), 0 3px 16px rgba(39, 44, 49, 0.07);
+  transition: all .5s ease;
+  background: white;
+  border-radius: 10px 10px 0 0;
+  margin: 20px 0;
+  padding-top: 10px; }
+  .section--devices .block-container:hover {
+    box-shadow: 8px 14px 38px rgba(39, 44, 49, 0.06), 1px 3px 8px rgba(39, 44, 49, 0.03);
+    transition: all .3s ease;
+    transform: translate3D(0, -1px, 0); }
+.section--devices .featureimg {
+  max-height: 400px;
+  max-width: 400px; }
 
 footer {
   margin-top: 150px; }

--- a/assets/css/pages/devices.css
+++ b/assets/css/pages/devices.css
@@ -46,24 +46,24 @@ section {
   padding-top: 60px; }
 .section--devices .row {
   padding-top: 60px; }
-.section--devices .col-md-4 {
+.section--devices .col-lg-4 {
   padding: 20px; }
 .section--devices .block-container {
-  height: 800px;
+  height: 1000px;
   overflow-y: auto;
-  box-shadow: 0 0 1px rgba(39, 44, 49, 0.1), 0 3px 16px rgba(39, 44, 49, 0.07);
   transition: all .5s ease;
   background: white;
   border-radius: 10px 10px 0 0;
   margin: 20px 0;
   padding-top: 10px; }
   .section--devices .block-container:hover {
-    box-shadow: 8px 14px 38px rgba(39, 44, 49, 0.06), 1px 3px 8px rgba(39, 44, 49, 0.03);
     transition: all .3s ease;
     transform: translate3D(0, -1px, 0); }
 .section--devices .featureimg {
-  max-height: 400px;
-  max-width: 400px; }
+  height: 200px;
+  width: auto; }
+.section--devices h3 {
+  height: 50px; }
 
 footer {
   margin-top: 150px; }

--- a/assets/css/pages/devices.scss
+++ b/assets/css/pages/devices.scss
@@ -27,13 +27,13 @@ section {
     .row {
         padding-top: 60px;
     }
-    .col-md-4 {
+    .col-lg-4 {
         padding: 20px;
     }
     .block-container {
-        height: 800px;
+        height: 1000px;
         overflow-y: auto;
-        box-shadow: 0 0 1px rgba(39,44,49,.1), 0 3px 16px rgba(39,44,49,.07);
+        //box-shadow: 0 0 1px rgba(39,44,49,.1), 0 3px 16px rgba(39,44,49,.07);
 		transition: all .5s ease;
 		background: white;
 		border-radius: 10px 10px 0 0;
@@ -41,15 +41,18 @@ section {
         padding-top: 10px;
 
 		&:hover {
-				box-shadow: 8px 14px 38px rgba(39,44,49,.06), 1px 3px 8px rgba(39,44,49,.03);
+				//box-shadow: 8px 14px 38px rgba(39,44,49,.06), 1px 3px 8px rgba(39,44,49,.03);
 				transition: all .3s ease;
 				transform: translate3D(0,-1px,0);
 		}
 
     }
     .featureimg {
-        max-height: 400px;
-        max-width: 400px;
+        height: 200px;
+        width: auto;
+    }
+    h3 {
+        height: 50px;
     }
 
 }

--- a/assets/css/pages/devices.scss
+++ b/assets/css/pages/devices.scss
@@ -19,14 +19,40 @@ section {
 	}
 }
 
-.feature--block {
-    padding-top: 60px;
-}
+.section--devices {
+    .feature--block {
+        padding-top: 60px;
+    }
 
-.row {
-	padding-top: 60px;
-}
+    .row {
+        padding-top: 60px;
+    }
+    .col-md-4 {
+        padding: 20px;
+    }
+    .block-container {
+        height: 800px;
+        overflow-y: auto;
+        box-shadow: 0 0 1px rgba(39,44,49,.1), 0 3px 16px rgba(39,44,49,.07);
+		transition: all .5s ease;
+		background: white;
+		border-radius: 10px 10px 0 0;
+		margin: 20px 0;
+        padding-top: 10px;
 
+		&:hover {
+				box-shadow: 8px 14px 38px rgba(39,44,49,.06), 1px 3px 8px rgba(39,44,49,.03);
+				transition: all .3s ease;
+				transform: translate3D(0,-1px,0);
+		}
+
+    }
+    .featureimg {
+        max-height: 400px;
+        max-width: 400px;
+    }
+
+}
 footer {
 	margin-top: 150px;
 }

--- a/page-devices.php
+++ b/page-devices.php
@@ -34,8 +34,8 @@ require(["require.config"], function() {
 <section class="section--devices">
 <div class="container-widest">
     <div class="row">
-        <h4>Currently available</h4>
-        <div class="col-md-4">
+<!--         <h4>Currently available</h4> -->
+        <div class="col-lg-4">
             <div class="block-container">
                 <div class="text-center">
                     <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-odroid-hc2/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/ubosbox-nextcloud-on-odroid-hc2-500x375.jpg" class="text-center featureimg" /></a>
@@ -54,11 +54,11 @@ require(["require.config"], function() {
                         <span>Commercial</span>
                         <span>Managed</span>
                     </div>
-                    <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
+                    <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/" class="button button--blue button--arrow button--large"><?php echo $l->t('More about UbosBox');?></a>
                 </div>
             </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-lg-4">
             <div class="block-container">
                 <div class="text-center">
                     <a href="https://shop.hanssonit.se/product-category/nextcloud/home-sme-server/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/nuc10side.jpeg" class="text-center featureimg" /></a>
@@ -74,11 +74,11 @@ require(["require.config"], function() {
                         <span>Commercial</span>
                         <span>Community</span>
                     </div>
-                    <a href="https://shop.hanssonit.se/product-category/nextcloud/home-sme-server/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
+                    <a href="https://shop.hanssonit.se/product-category/nextcloud/home-sme-server/" class="button button--blue button--arrow button--large"><?php echo $l->t('More about HanssonIT');?></a>
                 </div>
             </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-lg-4">
             <div class="block-container">
                 <div class="text-center">
                     <a href="<?php bloginfo('template_directory'); ?>/assets/img/devices/syncloud.jpg"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/syncloud.jpg" class="text-center featureimg" /></a>
@@ -90,11 +90,11 @@ require(["require.config"], function() {
                     <div class="devices-tags">
                         <span>Commercial</span>
                     </div>
-                    <a href="http://syncloud.org" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                    <a href="http://syncloud.org" class="button button--blue button--arrow button--large"><?php echo $l->t('More about Syncloud');?></a>
                 </div>
             </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-lg-4">
             <div class="block-container">
                 <div class="text-center">
                     <a href="https://www.homedrive.io/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/homedrive.png" class="text-center featureimg" /></a>
@@ -111,11 +111,11 @@ require(["require.config"], function() {
                         <span>Commercial</span>
                         <span>Managed</span>
                     </div>
-                    <a href="https://www.homedrive.io/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                    <a href="https://www.homedrive.io/" class="button button--blue button--arrow button--large"><?php echo $l->t('More about homedrive');?></a>
                 </div>
             </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-lg-4">
             <div class="block-container">
                 <div class="text-center">
                     <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/ubosbox-nextcloud-on-nuc-model-a-on-500x375.png" class="text-center featureimg" /></a>
@@ -134,11 +134,11 @@ require(["require.config"], function() {
                         <span>Commercial</span>
                         <span>Managed</span>
                     </div>
-                    <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
+                    <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/" class="button button--blue button--arrow button--large"><?php echo $l->t('More about Indiecomputing');?></a>
                 </div>
             </div>
         </div>
-        <div class="col-md-4">
+        <div class="col-lg-4">
             <div class="block-container">
                 <div class="text-center">
                     <img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/MOX.png" class="text-center featureimg" />
@@ -151,7 +151,7 @@ require(["require.config"], function() {
                     <div class="devices-tags">
                         <span>Commercial</span>
                     </div>
-                    <a href="https://nextcloud.com/blog/turris-mox-adds-nextcloud-to-put-users-back-in-control-over-their-data/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                    <a href="https://nextcloud.com/blog/turris-mox-adds-nextcloud-to-put-users-back-in-control-over-their-data/" class="button button--blue button--arrow button--large"><?php echo $l->t('More about Turris Mox');?></a>
                 </div>
             </div>
         <div>
@@ -159,7 +159,7 @@ require(["require.config"], function() {
 </div>
         <div class="row">
             <h4>Sold out, or not available any more</h4>
-            <div class="col-md-4">
+            <div class="col-lg-4">
                 <div class="block-container">
                     <div class="text-center">
                         <a href="https://spreedbox.me/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/spreedbox.png" class="text-center featureimg" /></a>
@@ -173,21 +173,21 @@ require(["require.config"], function() {
                         <div class="devices-tags">
                             <span>Commercial</span>
                         </div>
-                        <a href="https://spreedbox.me/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                        <a href="https://spreedbox.me/" class="button button--blue button--arrow button--large"><?php echo $l->t('More about spreedbox');?></a>
                     </div>
                 </div>
             </div>
-            <div class="col-md-4">
+            <div class="col-lg-4">
                 <div class="block-container">
-                    <div class="text-center">>
+                    <div class="text-center">
                         <a href="<?php echo home_url('box') ?>"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/box-perspective.png" class="text-center featureimg" /></a>
                     </div>
                         <div class="col-md-12">
-                            <h3 class="section--paragraph__title"><em><?php echo $l->t('Nextcloud Box');?></em></h3>
+                            <h3 class="section--paragraph__title"><?php echo $l->t('Nextcloud Box');?></h3>
                             <p class="section--paragraph"><?php echo $l->t('The Nextcloud Box comes preinstalled with Nextcloud, running on Ubuntu Core (based on the new super-secure, remotely upgradeable Linux app packages known as snaps) as the OS.');?></p>
                             <p class="section--paragraph"><?php echo $l->t('The box consists of a 1 TB USB3 hard drive from WDLabs, a Nextcloud case with room for the drive and a compute board, a microUSB charger, cables and adapters, a screw driver and screws');?></p>
                             <p class="section--paragraph"><strong><?php echo $l->t('Sadly, the box is sold out and no longer produced by WD Labs!');?></strong></p>
-                            <a href="<?php echo home_url('box') ?>" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                            <a href="<?php echo home_url('box') ?>" class="button button--blue button--arrow button--large"><?php echo $l->t('More about the Nc Box');?></a>
                         </div>
                     </div>
                 </div>

--- a/page-devices.php
+++ b/page-devices.php
@@ -16,7 +16,7 @@ require(["require.config"], function() {
 <div class="background sharing-background">
     <div class="container">
         <div class="row">
-            <div class="col-md-6 topheader">
+            <div class="col-md-4 topheader">
                 <h1><?php echo $l->t('Keep your server at home.');?></h1>
                 <h2><?php echo $l->t('Companies all around us build hardware Nextcloud runs on out of the box.');?></h2>
             </div>
@@ -32,147 +32,167 @@ require(["require.config"], function() {
 ?>
 
 <section class="section--devices">
-    <div class="container">
+<div class="container-widest">
+    <div class="row">
         <h4>Currently available</h4>
-        <div class="row feature--block">
-            <div class="col-md-5">
-                <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-odroid-hc2/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/ubosbox-nextcloud-on-odroid-hc2-500x375.jpg" class="img-responsive featureimg" /></a>
-            </div>
-            <div class="col-md-7">
-                <h3 class="section--paragraph__title"><?php echo $l->t('UBOSbox Nextcloud on ODROID-HC2 &ndash; Home/Office Server');?></h3>
-                <p class="section--paragraph"><em><?php echo $l->t('Large disk options on this NAS-class device');?></em></p>
-                <ul class="section--paragraph" style="list-style-type: disc">
-                    <li><?php echo $l->t('Preconfigured: UBOS Linux (pre-installed) and Nextcloud plus apps (auto-install on first boot)');?></li>
-                    <li><?php echo $l->t('Can be set up and maintained without attached monitor and keyboard')?></li>
-                    <li><?php echo $l->t('Choose from several large disk options up to 8TB (larger on request)')?></li>
-                    <li><?php echo $l->t('Easy day-to-day management: upgrades, backups, network configuration and more are just a single command')?></li>
-                    <li><?php echo $l->t('UBOS Live systems management service for automatic upgrades, remote systems diagnosis and troubleshooting (option)');?></li>
-                </ul>
-                <div class="devices-tags">
-                    <span>Commercial</span>
-                    <span>Managed</span>
+        <div class="col-md-4">
+            <div class="block-container">
+                <div class="text-center">
+                    <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-odroid-hc2/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/ubosbox-nextcloud-on-odroid-hc2-500x375.jpg" class="text-center featureimg" /></a>
                 </div>
-                <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
-            </div>
-        </div>
-        <div class="row feature--block">
-            <div class="col-md-5">
-                <a href="https://shop.hanssonit.se/product-category/nextcloud/home-sme-server/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/nuc10side.jpeg" class="img-responsive featureimg" /></a>
-            </div>
-            <div class="col-md-7">
-                <h3 class="section--paragraph__title"><?php echo $l->t('Nextcloud Home/SME Server');?></h3>
-                <p class="section--paragraph"><em><?php echo $l->t('Get your own self-hosted cloud server!');?></em></p>
-                <p class="section--paragraph"><?php echo $l->t('The Nextcloud Home/SME Server is a Nextcloud server pre-configured with Nextcloud and ready to boot once delivered. Just as the Nextcloud VM it includes easy to setup apps like Collabora, OnlyOffice, Talk and more.');?></p>
-                <p class="section--paragraph"><?php echo $l->t('Updates are managed with a easy-to-run update script which updates the whole server in just one single command. The server is based on a powerful Intel 64-bit CPU (10:th-gen), 500 GB M2 PCIe SSD + 2/4 TB HDD/SSD, and 16/32 GB RAM.');?></p>
-                <p class="section--paragraph"><?php echo $l->t('The Nextcloud Home/SME server is made by the team behind the Nextcloud VM, and aims to be the easiest way to setup your own cloud - now available as a bare-bone server!');?></p>
-                <div class="devices-tags">
-                    <span>Managed</span>
-                    <span>Commercial</span>
-                    <span>Community</span>
+                <div class="col-md-12">
+                    <h3 class="section--paragraph__title"><?php echo $l->t('UBOSbox Nextcloud on ODROID-HC2 &ndash; Home/Office Server');?></h3>
+                    <p class="section--paragraph"><em><?php echo $l->t('Large disk options on this NAS-class device');?></em></p>
+                    <ul class="section--paragraph" style="list-style-type: disc">
+                        <li><?php echo $l->t('Preconfigured: UBOS Linux (pre-installed) and Nextcloud plus apps (auto-install on first boot)');?></li>
+                        <li><?php echo $l->t('Can be set up and maintained without attached monitor and keyboard')?></li>
+                        <li><?php echo $l->t('Choose from several large disk options up to 8TB (larger on request)')?></li>
+                        <li><?php echo $l->t('Easy day-to-day management: upgrades, backups, network configuration and more are just a single command')?></li>
+                        <li><?php echo $l->t('UBOS Live systems management service for automatic upgrades, remote systems diagnosis and troubleshooting (option)');?></li>
+                    </ul>
+                    <div class="devices-tags">
+                        <span>Commercial</span>
+                        <span>Managed</span>
+                    </div>
+                    <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
                 </div>
-                <a href="https://shop.hanssonit.se/product-category/nextcloud/home-sme-server/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
             </div>
         </div>
-        <div class="row feature--block">
-            <div class="col-md-5">
-                <a href="<?php bloginfo('template_directory'); ?>/assets/img/devices/syncloud.jpg"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/syncloud.jpg" class="img-responsive featureimg" /></a>
-            </div>
-            <div class="col-md-7">
-                <h3 class="section--paragraph__title"><?php echo $l->t('Syncloud');?></h3>
-                <p class="section--paragraph"><em><?php echo $l->t('Syncloud is a home server device which fully supports Nextcloud.');?></em></p>
-                <p class="section--paragraph"><?php echo $l->t('It features easy installation and activation, selection of hardware among 10+ boards, easy use of external hard drives for storage, domain name for device and access to device through Internet, automatic HTTPS setup and more applications.');?></p>
-                <div class="devices-tags">
-                    <span>Commercial</span>
+        <div class="col-md-4">
+            <div class="block-container">
+                <div class="text-center">
+                    <a href="https://shop.hanssonit.se/product-category/nextcloud/home-sme-server/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/nuc10side.jpeg" class="text-center featureimg" /></a>
                 </div>
-                <a href="http://syncloud.org" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
-            </div>
-        </div>
-        <div class="row feature--block">
-            <div class="col-md-5">
-                <a href="https://www.homedrive.io/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/homedrive.png" class="img-responsive featureimg" /></a>
-            </div>
-            <div class="col-md-7">
-                <h3 class="section--paragraph__title"><?php echo $l->t('HomeDrive');?></h3>
-                <p class="section--paragraph"><em><?php echo $l->t('Easy Nextcloud hosting at home. Access your data anywhere in the world.');?></em></p>
-                <ul class="section--paragraph" style="list-style-type: disc">
-                    <li><?php echo $l->t('HomeDrive provides an easy way to host Nextcloud at your home. It requires zero configuration to work, and automatically updates itself.');?></li>
-                    <li><?php echo $l->t('Setting up HomeDrive is as simple as plugging it into your home router. You can start accessing your data under a custom domain name from anywhere in the world right away.')?></li>
-                    <li><?php echo $l->t('Traffic from and to your HomeDrive server is end-to-end encrypted to ensure security and your privacy.')?></li>
-                </ul>
-                <div class="devices-tags">
-                    <span>Commercial</span>
-                    <span>Managed</span>
+                <div class="col-md-12">
+                    <h3 class="section--paragraph__title"><?php echo $l->t('Nextcloud Home/SME Server');?></h3>
+                    <p class="section--paragraph"><em><?php echo $l->t('Get your own self-hosted cloud server!');?></em></p>
+                    <p class="section--paragraph"><?php echo $l->t('The Nextcloud Home/SME Server is a Nextcloud server pre-configured with Nextcloud and ready to boot once delivered. Just as the Nextcloud VM it includes easy to setup apps like Collabora, OnlyOffice, Talk and more.');?></p>
+                    <p class="section--paragraph"><?php echo $l->t('Updates are managed with a easy-to-run update script which updates the whole server in just one single command. The server is based on a powerful Intel 64-bit CPU (10:th-gen), 500 GB M2 PCIe SSD + 2/4 TB HDD/SSD, and 16/32 GB RAM.');?></p>
+                    <p class="section--paragraph"><?php echo $l->t('The Nextcloud Home/SME server is made by the team behind the Nextcloud VM, and aims to be the easiest way to setup your own cloud - now available as a bare-bone server!');?></p>
+                    <div class="devices-tags">
+                        <span>Managed</span>
+                        <span>Commercial</span>
+                        <span>Community</span>
+                    </div>
+                    <a href="https://shop.hanssonit.se/product-category/nextcloud/home-sme-server/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
                 </div>
-                <a href="https://www.homedrive.io/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
             </div>
         </div>
-        <div class="row feature--block">
-            <div class="col-md-5">
-                <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/ubosbox-nextcloud-on-nuc-model-a-on-500x375.png" class="img-responsive featureimg" /></a>
-            </div>
-            <div class="col-md-7">
-                <h3 class="section--paragraph__title"><?php echo $l->t('UBOSbox Nextcloud on NUC &ndash; Home/Office Server');?></h3>
-                <p class="section--paragraph"><em><?php echo $l->t('Fully-assembled based on Intel NUC with optional management service');?></em></p>
-                <ul class="section--paragraph" style="list-style-type: disc">
-                    <li><?php echo $l->t('Preconfigured: UBOS Linux (pre-installed) and Nextcloud plus apps (auto-install on first boot)');?></li>
-                    <li><?php echo $l->t('Can be set up and maintained without attached monitor and keyboard')?></li>
-                    <li><?php echo $l->t('Choose low power option for energy-conscious 24x7 operation or speed option for many concurrent users')?></li>
-                    <li><?php echo $l->t('Easy day-to-day management: upgrades, backups, network configuration and more are just a single command')?></li>
-                    <li><?php echo $l->t('UBOS Live systems management service for automatic upgrades, remote systems diagnosis and troubleshooting (option)');?></li>
-                </ul>
-                <div class="devices-tags">
-                    <span>Commercial</span>
-                    <span>Managed</span>
+        <div class="col-md-4">
+            <div class="block-container">
+                <div class="text-center">
+                    <a href="<?php bloginfo('template_directory'); ?>/assets/img/devices/syncloud.jpg"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/syncloud.jpg" class="text-center featureimg" /></a>
                 </div>
-                <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
-            </div>
-        </div>
-        <div class="row feature--block">
-            <div class="col-md-5">
-                <img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/MOX.png" class="img-responsive featureimg" />
-            </div>
-            <div class="col-md-7">
-                <h3 class="section--paragraph__title"><?php echo $l->t('Turris MOX: Cloud');?></h3>
-                <p class="section--paragraph"><em><?php echo $l->t('Modular router comes with private cloud module.');?></em></p>
-                <p class="section--paragraph"><?php echo $l->t('The Turris MOX: Cloud bundle  is a ready-to-go kit with a 64bit dualcore CPU, 1GB RAM, wifi connectivity and four USB 3.0 ports for attaching storage. The MOX makes it easy for users to set up RAID storage and Nextcloud for hosting and can be extended with other router modules like network ports.');?></p>
-                <p class="section--paragraph"><?php echo $l->t('The Turris MOX: Cloud bundle is available for pre-order with a 34% discount for 115 dollar until the end of the fundraising. Final pricing to be determined.');?></p>
-                <div class="devices-tags">
-                    <span>Commercial</span>
+                <div class="col-md-12">
+                    <h3 class="section--paragraph__title"><?php echo $l->t('Syncloud');?></h3>
+                    <p class="section--paragraph"><em><?php echo $l->t('Syncloud is a home server device which fully supports Nextcloud.');?></em></p>
+                    <p class="section--paragraph"><?php echo $l->t('It features easy installation and activation, selection of hardware among 10+ boards, easy use of external hard drives for storage, domain name for device and access to device through Internet, automatic HTTPS setup and more applications.');?></p>
+                    <div class="devices-tags">
+                        <span>Commercial</span>
+                    </div>
+                    <a href="http://syncloud.org" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
                 </div>
-                <a href="https://nextcloud.com/blog/turris-mox-adds-nextcloud-to-put-users-back-in-control-over-their-data/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
             </div>
         </div>
-
-        <h4>Sold out, or not available any more</h4>
-        <div class="row feature--block">
-            <div class="col-md-5">
-                <a href="https://spreedbox.me/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/spreedbox.png" class="img-responsive featureimg" /></a>
-            </div>
-            <div class="col-md-7">
-                <h3 class="section--paragraph__title"><?php echo $l->t('Spreedbox');?></h3>
-                <p class="section--paragraph"><?php echo $l->t('Behind the award-winning designed device by struktur AG operates a secure video chat and file exchange solution for small enterprise usage.');?></p>
-                <p class="section--paragraph"><?php echo $l->t('It offers Strong end-to-end encrypted audio and video chat, a Nextcloud based file sync and share solution and advanced security features with a silicon hardware key generator.');?></p>
-                <p class="section--paragraph"><?php echo $l->t('The Spreedbox offers an optional SIP gateway, enabling web conferencing participants to dial in through a traditional telephone connection.');?></p>
-                <p class="section--paragraph"><?php echo $l->t('Pricing is in the Eur 1500/USD 1500 range.');?></p>
-                <div class="devices-tags">
-                    <span>Commercial</span>
+        <div class="col-md-4">
+            <div class="block-container">
+                <div class="text-center">
+                    <a href="https://www.homedrive.io/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/homedrive.png" class="text-center featureimg" /></a>
                 </div>
-                <a href="https://spreedbox.me/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                <div class="col-md-12">
+                    <h3 class="section--paragraph__title"><?php echo $l->t('HomeDrive');?></h3>
+                    <p class="section--paragraph"><em><?php echo $l->t('Easy Nextcloud hosting at home. Access your data anywhere in the world.');?></em></p>
+                    <ul class="section--paragraph" style="list-style-type: disc">
+                        <li><?php echo $l->t('HomeDrive provides an easy way to host Nextcloud at your home. It requires zero configuration to work, and automatically updates itself.');?></li>
+                        <li><?php echo $l->t('Setting up HomeDrive is as simple as plugging it into your home router. You can start accessing your data under a custom domain name from anywhere in the world right away.')?></li>
+                        <li><?php echo $l->t('Traffic from and to your HomeDrive server is end-to-end encrypted to ensure security and your privacy.')?></li>
+                    </ul>
+                    <div class="devices-tags">
+                        <span>Commercial</span>
+                        <span>Managed</span>
+                    </div>
+                    <a href="https://www.homedrive.io/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                </div>
             </div>
         </div>
-        <div class="row feature--block" id="nextcloud-box">
-            <div class="col-md-5">
-                <a href="<?php echo home_url('box') ?>"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/box-perspective.png" class="img-responsive featureimg" /></a>
-            </div>
-            <div class="col-md-7">
-                <h3 class="section--paragraph__title"><em><?php echo $l->t('Nextcloud Box');?></em></h3>
-                <p class="section--paragraph"><?php echo $l->t('The Nextcloud Box comes preinstalled with Nextcloud, running on Ubuntu Core (based on the new super-secure, remotely upgradeable Linux app packages known as snaps) as the OS.');?></p>
-                <p class="section--paragraph"><?php echo $l->t('The box consists of a 1 TB USB3 hard drive from WDLabs, a Nextcloud case with room for the drive and a compute board, a microUSB charger, cables and adapters, a screw driver and screws');?></p>
-                <p class="section--paragraph"><strong><?php echo $l->t('Sadly, the box is sold out and no longer produced by WD Labs!');?></strong></p>
-                <a href="<?php echo home_url('box') ?>" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+        <div class="col-md-4">
+            <div class="block-container">
+                <div class="text-center">
+                    <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/ubosbox-nextcloud-on-nuc-model-a-on-500x375.png" class="text-center featureimg" /></a>
+                </div>
+                <div class="col-md-12">
+                    <h3 class="section--paragraph__title"><?php echo $l->t('UBOSbox Nextcloud on NUC &ndash; Home/Office Server');?></h3>
+                    <p class="section--paragraph"><em><?php echo $l->t('Fully-assembled based on Intel NUC with optional management service');?></em></p>
+                    <ul class="section--paragraph" style="list-style-type: disc">
+                        <li><?php echo $l->t('Preconfigured: UBOS Linux (pre-installed) and Nextcloud plus apps (auto-install on first boot)');?></li>
+                        <li><?php echo $l->t('Can be set up and maintained without attached monitor and keyboard')?></li>
+                        <li><?php echo $l->t('Choose low power option for energy-conscious 24x7 operation or speed option for many concurrent users')?></li>
+                        <li><?php echo $l->t('Easy day-to-day management: upgrades, backups, network configuration and more are just a single command')?></li>
+                        <li><?php echo $l->t('UBOS Live systems management service for automatic upgrades, remote systems diagnosis and troubleshooting (option)');?></li>
+                    </ul>
+                    <div class="devices-tags">
+                        <span>Commercial</span>
+                        <span>Managed</span>
+                    </div>
+                    <a href="https://indiecomputing.com/products/ubosbox-nextcloud-on-nuc/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more and order');?></a>
+                </div>
             </div>
         </div>
-
+        <div class="col-md-4">
+            <div class="block-container">
+                <div class="text-center">
+                    <img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/MOX.png" class="text-center featureimg" />
+                </div>
+                <div class="col-md-12">
+                    <h3 class="section--paragraph__title"><?php echo $l->t('Turris MOX: Cloud');?></h3>
+                    <p class="section--paragraph"><em><?php echo $l->t('Modular router comes with private cloud module.');?></em></p>
+                    <p class="section--paragraph"><?php echo $l->t('The Turris MOX: Cloud bundle  is a ready-to-go kit with a 64bit dualcore CPU, 1GB RAM, wifi connectivity and four USB 3.0 ports for attaching storage. The MOX makes it easy for users to set up RAID storage and Nextcloud for hosting and can be extended with other router modules like network ports.');?></p>
+                    <p class="section--paragraph"><?php echo $l->t('The Turris MOX: Cloud bundle is available for pre-order with a 34% discount for 115 dollar until the end of the fundraising. Final pricing to be determined.');?></p>
+                    <div class="devices-tags">
+                        <span>Commercial</span>
+                    </div>
+                    <a href="https://nextcloud.com/blog/turris-mox-adds-nextcloud-to-put-users-back-in-control-over-their-data/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                </div>
+            </div>
+        <div>
+    </div>
+</div>
+        <div class="row">
+            <h4>Sold out, or not available any more</h4>
+            <div class="col-md-4">
+                <div class="block-container">
+                    <div class="text-center">
+                        <a href="https://spreedbox.me/"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/spreedbox.png" class="text-center featureimg" /></a>
+                    </div>
+                    <div class="col-md-12">
+                        <h3 class="section--paragraph__title"><?php echo $l->t('Spreedbox');?></h3>
+                        <p class="section--paragraph"><?php echo $l->t('Behind the award-winning designed device by struktur AG operates a secure video chat and file exchange solution for small enterprise usage.');?></p>
+                        <p class="section--paragraph"><?php echo $l->t('It offers Strong end-to-end encrypted audio and video chat, a Nextcloud based file sync and share solution and advanced security features with a silicon hardware key generator.');?></p>
+                        <p class="section--paragraph"><?php echo $l->t('The Spreedbox offers an optional SIP gateway, enabling web conferencing participants to dial in through a traditional telephone connection.');?></p>
+                        <p class="section--paragraph"><?php echo $l->t('Pricing is in the Eur 1500/USD 1500 range.');?></p>
+                        <div class="devices-tags">
+                            <span>Commercial</span>
+                        </div>
+                        <a href="https://spreedbox.me/" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="block-container">
+                    <div class="text-center">>
+                        <a href="<?php echo home_url('box') ?>"><img src="<?php bloginfo('template_directory'); ?>/assets/img/devices/box-perspective.png" class="text-center featureimg" /></a>
+                    </div>
+                        <div class="col-md-12">
+                            <h3 class="section--paragraph__title"><em><?php echo $l->t('Nextcloud Box');?></em></h3>
+                            <p class="section--paragraph"><?php echo $l->t('The Nextcloud Box comes preinstalled with Nextcloud, running on Ubuntu Core (based on the new super-secure, remotely upgradeable Linux app packages known as snaps) as the OS.');?></p>
+                            <p class="section--paragraph"><?php echo $l->t('The box consists of a 1 TB USB3 hard drive from WDLabs, a Nextcloud case with room for the drive and a compute board, a microUSB charger, cables and adapters, a screw driver and screws');?></p>
+                            <p class="section--paragraph"><strong><?php echo $l->t('Sadly, the box is sold out and no longer produced by WD Labs!');?></strong></p>
+                            <a href="<?php echo home_url('box') ?>" class="button button--blue button--arrow button--large"><?php echo $l->t('Learn more');?></a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 </section>


### PR DESCRIPTION
I wanted to make the devices page a bit more compact, as there will probably be more and more over time and getting an overview gets harder. Of course, on mobile this doesn't make it much better but on a bigger screen it helps.

## Before
![screencapture-nextcloud-devices-2021-01-19-13_59_53](https://user-images.githubusercontent.com/551757/105038799-11fbb180-5a60-11eb-854c-31242b680f14.png)


## After
![screencapture-127-0-0-1-wordpress-devices-2021-01-19-14_00_05](https://user-images.githubusercontent.com/551757/105037974-0a87d880-5a5f-11eb-8ece-b9d2296e20a2.png)


Signed-off-by: Jos Poortvliet <jospoortvliet@gmail.com>