### PR TITLE
Reduce ratelimits

### DIFF
--- a/lib/ratelimiter.php
+++ b/lib/ratelimiter.php
@@ -37,6 +37,15 @@ function canPerformLimitedAction($ratelimitName, $maxRequestsPerHour) : bool {
     $rateId    = "requests_count_ratelimiter_{$ratelimitName}_{$userIp}";
     $rateLimit = (int) $redis->get($rateId);
 
+    $globalRateId    = "requests_count_ratelimiter_{$userIp}";
+    $globalRateLimit = (int) $redis->get($globalRateId);
+    $redis->set($globalRateId, $globalRateLimit + 1);
+    $redis->expire($globalRateId, 3600);
+    $globalRateLimitMaximumPerHour = 20;
+    if ($globalRateLimit + 1 > $globalRateLimitMaximumPerHour) {
+        return false;
+    }
+
     $redis->set($rateId, $rateLimit + 1);
     $redis->expire($rateId, 3600);
 

--- a/page-appmarketingsubmit.php
+++ b/page-appmarketingsubmit.php
@@ -26,7 +26,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("appmarketing-submit-action", 10)) {
+if(!canPerformLimitedAction("appmarketing-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-contactsubmit.php
+++ b/page-contactsubmit.php
@@ -45,7 +45,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("contact-submit-action", 10)) {
+if(!canPerformLimitedAction("contact-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-includesubmit.php
+++ b/page-includesubmit.php
@@ -21,7 +21,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("appmarketing-submit-action", 10)) {
+if(!canPerformLimitedAction("appmarketing-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-ionossubmit.php
+++ b/page-ionossubmit.php
@@ -22,7 +22,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("ionos-submit-action", 10)) {
+if(!canPerformLimitedAction("ionos-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-ordersubmit.php
+++ b/page-ordersubmit.php
@@ -21,7 +21,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("order-submit-action", 10)) {
+if(!canPerformLimitedAction("order-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-partnerapplysubmit.php
+++ b/page-partnerapplysubmit.php
@@ -22,7 +22,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("partnerapply-submit-action", 10)) {
+if(!canPerformLimitedAction("partnerapply-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-providersubmit.php
+++ b/page-providersubmit.php
@@ -19,7 +19,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("provider-submit-action", 10)) {
+if(!canPerformLimitedAction("provider-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-publiclettersubmit.php
+++ b/page-publiclettersubmit.php
@@ -19,7 +19,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("publicletter-submit-action", 10)) {
+if(!canPerformLimitedAction("publicletter-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-quotesubmit.php
+++ b/page-quotesubmit.php
@@ -46,7 +46,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("sales-submit-action", 10)) {
+if(!canPerformLimitedAction("sales-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 

--- a/page-trialsubmit.php
+++ b/page-trialsubmit.php
@@ -46,7 +46,7 @@
 <?php
 require_once realpath(dirname(__FILE__)) . '/lib/ratelimiter.php';
 
-if(!canPerformLimitedAction("trial-submit-action", 10)) {
+if(!canPerformLimitedAction("trial-submit-action", 2)) {
   die("Too many requests. Please try again later.");
 }
 


### PR DESCRIPTION
Moved the ratelimits per form down to usually 2 per hour.
Added a global ratelimit of 20 requests per hour.

