### PR TITLE
fix: add rel=me to mastodon

### DIFF
--- a/templates/footer.php
+++ b/templates/footer.php
@@ -88,7 +88,7 @@ $l = new L10N('footer');
                 <li><a href="https://www.linkedin.com/company/10827569/"><?php echo $l->t('LinkedIn'); ?></a></li>
                 <li><a href="https://youtube.com/nextcloud"><?php echo $l->t('YouTube'); ?></a></li>
                 <li><a href="https://twitter.com/nextclouders"><?php echo $l->t('Twitter'); ?></a></li>
-                <li><a href="https://mastodon.xyz/@nextcloud"><?php echo $l->t('Mastodon'); ?></a></li>
+                <li><a rel="me" href="https://mastodon.xyz/@nextcloud"><?php echo $l->t('Mastodon'); ?></a></li>
                 <li><a href="<?php echo home_url('podcast'); ?>"><?php echo $l->t('Podcast'); ?></a></li>
                 <li><a href="<?php echo home_url('blogfeed'); ?>">RSS <?php echo $l->t('Feed'); ?></a></li>
             </ul>


### PR DESCRIPTION
Minor pet peeve, but on Mastodon your site isn't verified because it doesn't have `rel="me"` in the HTML.

![image](https://user-images.githubusercontent.com/22801583/132126035-e55cd6d1-f1ca-4170-aafa-a0b6eeac8700.png)

> If you put a link in your profile metadata, Mastodon checks if the linked page links back to your Mastodon profile. If so, you get a verification checkmark next to that link, since you are confirmed as the owner.
> 
> Behind the scenes, Mastodon checks for the `rel="me"` attribute on the link back. Likewise, Mastodon puts `rel="me"` on the links within profile metadata.
> — https://docs.joinmastodon.org/user/profile/

After this, it should display it as a verified link. That way users don't have to manually check the website to ensure this is the official Nextcloud account on Mastodon.

![image](https://user-images.githubusercontent.com/22801583/132126091-9fe66f7b-223f-493a-bee2-2d22c04c9e75.png)
