### PR TITLE
Remove deprecated name attribute

### DIFF
--- a/page-about.php
+++ b/page-about.php
@@ -138,7 +138,7 @@
             </ul>
         </p>
     </div>
-    <a name="history"></a>
+    <a id="history"></a>
     <div class="row floating--quote--container">
         <blockquote class="quote--paragraph">Nextcloud hit the ground running</blockquote>
         <div class="quote--brand">

--- a/page-athome.php
+++ b/page-athome.php
@@ -33,7 +33,7 @@
 </div>
 
 <section class="section--hosting">
-	<a name="hosting" id="hosting"></a>
+	<a id="hosting"></a>
 	<div class="container">
 		<div class="col-md-6">
 			<img class="img-responsive acess__anywhere" src="<?php echo get_template_directory_uri(); ?>/assets/img/common/access-anywhere.png" alt="in action" >
@@ -48,7 +48,7 @@
 </section>
 
 <section class="section--on-premise">
-    <a name="selfhosting" id="selfhosting"></a>
+    <a id="selfhosting"></a>
 <div class="container">
 	<h1 class="section--heading-1 text-center"><?php echo $l->t('Why self-hosting?');?></h1>
 	<div class="row">
@@ -106,7 +106,7 @@
 </section>
 
 <section class="section--files">
-	<a name="files" id="files"></a>
+	<a id="files"></a>
 	<div class="container">
 		<div class="col-md-6 image--floated">
 			<div data-type="youtube" data-video-id="Fe1I7wYW6hA"></div>
@@ -121,7 +121,7 @@
 </section>
 
 <section class="section--files">
-	<a name="files" id="files"></a>
+	<a id="files"></a>
 	<div class="container">
 		<div class="col-md-6 image--feature new-img">
             <img class="img-responsive featureimg overlay-trigger" src="<?php echo get_template_directory_uri(); ?>/assets/img/features/Admin_Overview_Security_and_setup_warnings.png" alt="in action" >
@@ -149,7 +149,7 @@
 </section>
 
 <section class="section--security">
-	<a name="security" id="security"></a>
+	<a id="security"></a>
 	<div class="container">
 		<div class="col-md-6 image--feature">
 		<img class="overlay-trigger img-responsive featureimg" src="<?php echo get_template_directory_uri(); ?>/assets/img/features/TOTP.png" alt="in action" >
@@ -183,7 +183,7 @@
 
 
 <section class="section--clients">
-	<a name="clients" id="clients"></a>
+	<a id="clients"></a>
 	<div class="container">
 		<div class="col-md-6 image--feature">
 			<img class="img-responsive featureimg" src="<?php bloginfo('template_directory'); ?>/assets/img/features/mobileDesktop.png">
@@ -197,7 +197,7 @@
 </section>
 
 <section class="section--Calendar">
-	<a name="calendar" id="calendar"></a>
+	<a id="calendar"></a>
 	<div class="container">
 		<div class="col-md-6 image--floated image--feature">
 			<div style="padding:75% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/555693729?badge=0&amp;autopause=0&amp;dnt=1&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Nextcloud Groupware video"></iframe></div>
@@ -210,7 +210,7 @@
 </section>
 
 <section class="section--calls">
-	<a name="calls" id="calls"></a>
+	<a id="calls"></a>
 	<div class="container">
 		<div class="col-md-6 image--feature">
 			<div style="padding:75% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/555693791?badge=0&amp;autopause=0&amp;dnt=1&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Nextcloud Talk video"></iframe></div>
@@ -237,7 +237,7 @@
 </section>
 
 <section class="section--picocms">
-	<a name="picocms" id="picocms">
+	<a id="picocms">
 	<div class="container">
 		<div class="col-md-6 image--feature">
 			<a><img class="overlay-trigger img-responsive featureimg" src="<?php bloginfo('template_directory'); ?>/assets/img/features/picocms-nw.png"/></a>
@@ -252,7 +252,7 @@
 </section>
 
 <section class="section--Collabora">
-	<a name="collabora" id="collabora"></a>
+	<a id="collabora"></a>
 	<div class="container">
 		<div class="col-md-6 image--feature image--floated">
 			<div style="padding:75% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/555693791?badge=0&amp;autopause=0&amp;dnt=1&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="Document editing video"></iframe></div>
@@ -284,7 +284,7 @@
 </div>
 </section>
 
-<a name="calendar" id="calendar"></a>
+<a id="calendar"></a>
 <section class="section--outlook quote">
 <div class="container">
     <div class="featurerow">
@@ -321,7 +321,7 @@
 </section>
 
 <section class="section--usermanagement">
-	<a name="storage" id="storage"></a>
+	<a id="storage"></a>
 	<div class="container">
         <div class="col-md-6 image--feature new-img image--floated">
             <a class="overlay-trigger " href="<?php bloginfo('template_directory'); ?>/assets/img/features/usermanagement.png"><img class="img-responsive featureimg" src="<?php echo get_template_directory_uri(); ?>/assets/img/features/usermanagement.png" alt="in action" ></a>
@@ -335,7 +335,7 @@
 </section>
 
 <section class="section--workflow">
-	<a name="workflow" id="workflow"></a>
+	<a id="workflow"></a>
 	<div class="container">
 		<div class="col-md-6 image--feature new-img">
 			<a><img class="overlay-trigger img-responsive featureimg" src="<?php echo get_template_directory_uri(); ?>/assets/img/features/flow-as-user.png" alt="in action"/></a>
@@ -349,7 +349,7 @@
 </section>
 
 <section class="section--monitoring">
-    <a name="monitoring" id="monitoring"></a>
+    <a id="monitoring"></a>
     <div class="container">
         <div class="col-md-6 image--feature image--floated new-img">
             <a><img class="overlay-trigger img-responsive featureimg" src="<?php echo get_template_directory_uri(); ?>/assets/img/features/monitoring.png" alt="in action"/></a>
@@ -365,7 +365,7 @@
 </section>
 
 <section class="section--storage">
-	<a name="storage" id="storage"></a>
+	<a id="storage"></a>
 	<div class="container">
 		<div class="col-md-6 image--feature new-img">
 			<a><img class="overlay-trigger img-responsive featureimg" src="<?php bloginfo('template_directory'); ?>/assets/img/features/externalstorage.png"/></a>
@@ -407,7 +407,7 @@
 
 
 <section class="section--more">
-	<a name="more" id="more"></a>
+	<a id="more"></a>
 <div class="container-widest">
 	<h1 class="section--heading-1 section--text--center"><?php echo $l->t('And much more.');?></h1>
     <div class="row">

--- a/page-changelog.php
+++ b/page-changelog.php
@@ -35,7 +35,7 @@
     </ul>
 <p>Note here that with 'supported' in this context we mean that software updates will be available to the public, not that there is any actual support beyond community members answering questions in our home user forums. If you need to run Nextcloud in an enterprise setting, we recommend <a class="hyperlink" href="https://nextcloud.com/enterprise">Nextcloud Enterprise.</a></p>
 
-<a name="latest22"></a>
+<a id="latest22"></a>
 
 <h3 id="22-1-1">Version 22.1.1 <small>August 29 2021</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-22.1.1.tar.bz2">nextcloud-22.1.1.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-22.1.1.zip">nextcloud-22.1.1.zip</a></br>
@@ -258,7 +258,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
 <p>A full changelog would be to long to reproduce here, given the core server alone had over 600 PR's merged.</p>
 <p>You can find a list of PR's for the core server, without dependency bumps, <a href="https://github.com/nextcloud/server/pulls?q=is%3Apr+milestone%3A%22Nextcloud+22%22+is%3Aclosed+sort%3Acreated-asc+is%3Amerged+NOT+bump+">here.</a> If you replace 'server' in the URL above with, for example, <a href="https://github.com/nextcloud/viewer/pulls?q=is%3Apr+milestone%3A%22Nextcloud+22%22+is%3Aclosed+sort%3Acreated-asc+is%3Amerged+NOT+bump+">viewer</a>, <a href="https://github.com/nextcloud/activity/pulls?q=is%3Apr+milestone%3A%22Nextcloud+22%22+is%3Aclosed+sort%3Acreated-asc+is%3Amerged+NOT+bump+">activity</a>, <a href="https://github.com/nextcloud/photos/pulls?q=is%3Apr+milestone%3A%22Nextcloud+22%22+is%3Aclosed+sort%3Acreated-asc+is%3Amerged+NOT+bump+">photos</a>, <a href="https://github.com/nextcloud/notifications/pulls?q=is%3Apr+milestone%3A%22Nextcloud+22%22+is%3Aclosed+sort%3Acreated-asc+is%3Amerged+NOT+bump+">notifications</a> or <a href="https://github.com/nextcloud/text/pulls?q=is%3Apr+milestone%3A%22Nextcloud+22%22+is%3Aclosed+sort%3Acreated-asc+is%3Amerged+NOT+bump+">text</a>, the changes in the respective apps will show up.</p>
 
-<a name="latest21"></a>
+<a id="latest21"></a>
 
 <h3 id="21-0-4">Version 21.0.4 <small>August 6 2021</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-21.0.4.tar.bz2">nextcloud-21.0.4.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-21.0.4.zip">nextcloud-21.0.4.zip</a></br>
@@ -601,7 +601,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
 <p><a href="https://nextcloud.com/blog/nextcloud-hub-21-out-with-up-to-10x-better-performance-whiteboard-and-more-collaboration-features/">Read the full announcement on our blog.</a></p>
 <p>An exhaustive changelog would be unreasonably long, but one can always see our entire development history in github. For the core Server repository, see for example <a href="https://github.com/nextcloud/server/milestone/120?closed=1">here the 762 pull requests merged for Milestone 21.</a></p>
 
-<a name="latest20"></a>
+<a id="latest20"></a>
 
 <h3 id="20-0-12">Version 20.0.12 <small>August 6 2021</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-20.0.12.tar.bz2">nextcloud-20.0.12.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-20.0.12.zip">nextcloud-20.0.12.zip</a></br>
@@ -1321,7 +1321,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
 <p><a href="https://nextcloud.com/blog/nextcloud-hub-20-debuts-dashboard-unifies-search-and-notifications-integrates-with-other-technologies/">Read the full announcement on our blog.</a></p>
 <p>An exhaustive changelog would be unreasonably long, but one can always see our entire development history in github. For the core Server repository, see for example <a href="https://github.com/nextcloud/server/milestone/117?closed=1">here the 783 pull requests merged for Milestone 20.</a></p>
 
-<a name="latest19"></a>
+<a id="latest19"></a>
 
 <h3 id="19-0-13">Version 19.0.13 <small>July 2 2021</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-19.0.13.tar.bz2">nextcloud-19.0.13.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-19.0.13.zip">nextcloud-19.0.13.zip</a></br>
@@ -1967,7 +1967,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
 </ul>
 <p>Read the <a class="hyperlink" href="https://nextcloud.com/blog/nextcloud-hub-brings-productivity-to-home-office/">release announcement</a> for more details.</p>
 
-<a name="latest18"></a>
+<a id="latest18"></a>
 
 <h3 id="18-0-14">Version 18.0.14 <small>January 27 2021</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-18.0.14.tar.bz2">nextcloud-18.0.14.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-18.0.14.zip">nextcloud-18.0.14.zip</a></br>
@@ -2662,7 +2662,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
 </ul>
 <p>Read the <a class="hyperlink" href="https://nextcloud.com/blog/the-new-standard-in-on-premises-team-collaboration-nextcloud-hub/">release announcement</a> for more details.</p>
 
-<a name="latest17"></a>
+<a id="latest17"></a>
 <h3 id="17-0-10">Version 17.0.10 <small>October 9 2020</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-17.0.10.tar.bz2">nextcloud-17.0.10.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-17.0.10.zip">nextcloud-17.0.10.zip</a></br>
 Check the file integrity with:</br>
@@ -3079,7 +3079,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
 </ul>
 <p>Read the <a class="hyperlink" href="https://nextcloud.com/blog/nextcloud-17-brings-remote-wipe-collaborative-text-editor-and-next-generation-secure-watermarking/">release announcement</a> and blogs it links to for more details.</p>
 
-    <a name="latest16"></a>
+    <a id="latest16"></a>
 
 <h3 id="16-0-11">Version 16.0.11 <small>June 9 2020</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-16.0.11.tar.bz2">nextcloud-16.0.11.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-16.0.11.zip">nextcloud-16.0.11.zip</a></br>
@@ -3607,7 +3607,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
         <li><a href="https://nextcloud.com/blog/talk-6.0-brings-commands-improved-user-experience-and-more/">Talk 6.0 brings commands, improved user experience and more</a></li>
     </ul>
 
-    <a name="latest15"></a>
+    <a id="latest15"></a>
 
 <h3 id="15-0-14">Version 15.0.14 <small>December 20 2019</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-15.0.14.tar.bz2">nextcloud-15.0.14.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-15.0.14.zip">nextcloud-15.0.14.zip</a></br>
@@ -4329,7 +4329,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
         <li><a href="https://github.com/nextcloud/survey_client/pull/87">Update stable15 target versions (survey_client#87)</a></li>
     </ul>
 
-    <a name="latest14"></a>
+    <a id="latest14"></a>
 
 <h3 id="14-0-14">Version 14.0.14 <small>August 16 2019</small></h3>
 <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-14.0.14.tar.bz2">nextcloud-14.0.14.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-14.0.14.zip">nextcloud-14.0.14.zip</a></br>
@@ -4836,7 +4836,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
     </ul>
     <p><a href="https://nextcloud.com/blog/nextcloud-14-now-available-with-video-verification-signaltelegram-2fa-support-improved-collaboration-and-gdpr-compliance/">Our blog with more details is here.</a></p>
 
-    <a name="latest13"></a>
+    <a id="latest13"></a>
 
     <h3 id="13-0-12">Version 13.0.12 <small>February 29 2019</small></h3>
     <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-13.0.12.tar.bz2">nextcloud-13.0.12.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-13.0.12.zip">nextcloud-13.0.12.zip</a></br>
@@ -5337,7 +5337,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
     <p><a href="https://github.com/nextcloud/server/milestone/20?closed=1">See a full list of integrated pull requests here.</a></p>
 
 
-    <a name="latest12"></a>
+    <a id="latest12"></a>
 
     <h4 id="12-0-13">Version 12.0.13 <small>November 22 2018</small></h4>
     <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-12.0.13.tar.bz2">nextcloud-12.0.13.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-12.0.13.zip">nextcloud-12.0.13.zip</a></br>
@@ -5900,7 +5900,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
     <p><a href="https://nextcloud.com/blog/welcome-to-nextcloud-12/">Release announcement with overview about features and changes</a></p>
     <p><a href="https://github.com/nextcloud/server/milestone/10?closed=1">See a full list of integrated pull requests here.</a></p>
 
-    <a name="latest11"></a>
+    <a id="latest11"></a>
     <h3 id="11-0-8">Version 11.0.8 <small>March 15 2018</small></h3>
     <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-11.0.8.tar.bz2">nextcloud-11.0.8.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-11.0.8.zip">nextcloud-11.0.8.zip</a></br>
     Check the file integrity with:</br>
@@ -6257,7 +6257,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
     <p><a href="https://nextcloud.com/blog/nextcloud-11-sets-new-standard-for-security-and-scalability/">Release announcement with overview about features and changes</a></p>
     <p><a href="https://github.com/nextcloud/server/milestone/6?closed=1">See a full list of integrated pull requests here.</a></p>
 
-    <a name="latest10"></a>
+    <a id="latest10"></a>
     <h3 id="10-0-6">Version 10.0.6 <small>August 7 2017</small></h3>
     <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-10.0.6.tar.bz2">nextcloud-10.0.6.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-10.0.6.zip">nextcloud-10.0.6.zip</a></br>
     Check the file integrity with:</br>
@@ -6517,7 +6517,7 @@ PGP (<a href="https://nextcloud.com/nextcloud.asc">Key</a>): <a href="https://do
         <li>Additional configuration switch to use application specific passwords for desktop clients</li>
     </ul>
 
-    <a name="latest9"></a>
+    <a id="latest9"></a>
     <h3 id="9-0-58">Version 9.0.58 <small>April 24 2017</small></h3>
     <p>Download: <a href="https://download.nextcloud.com/server/releases/nextcloud-9.0.58.tar.bz2">nextcloud-9.0.58.tar.bz2</a> or <a href="https://download.nextcloud.com/server/releases/nextcloud-9.0.58.zip">nextcloud-9.0.58.zip</a></br>
     Check the file integrity with:</br>

--- a/page-collaboraonline.php
+++ b/page-collaboraonline.php
@@ -294,7 +294,7 @@ ProxyPass           /hosting/capabilities https://127.0.0.1:9980/hosting/capabil
 ProxyPassReverse    /hosting/capabilities https://127.0.0.1:9980/hosting/capabilities
 &lt;/VirtualHost&gt;
 			</code></pre></p>
-			<a name="update"></a>
+			<a id="update"></a>
 			<p class="section--paragraph"><?php echo $l->t('After configuring these do restart your apache using <code>/etc/init.d/apache2 restart</code>.');?></p>
 			<h3 class="section--paragraph__title"><?php echo $l->t('3. Configure the app in Nextcloud');?></h3>
 			<ol>

--- a/page-education.php
+++ b/page-education.php
@@ -158,7 +158,7 @@ require(["require.config"], function() {
     </div>
 </section>
 
-<a name="eduedition"></a>
+<a id="eduedition"></a>
 <div class="separator"></div>
 <section class="section--eduedition">
 <div class="container">
@@ -236,7 +236,7 @@ require(["require.config"], function() {
     </div>
 </section>
 
-<a name="easy"></a>
+<a id="easy"></a>
 <section class="section--easy">
 	<div class="container">
         <div class="row">
@@ -334,7 +334,7 @@ require(["require.config"], function() {
 	</div>
 </section>
 
-<a name="scalability"></a>
+<a id="scalability"></a>
 <section class="section--scalability">
 <div class="container">
     <div class="row">
@@ -429,7 +429,7 @@ require(["require.config"], function() {
 </section>
 
 <div class="separator"></div>
-<a name="control"></a>
+<a id="control"></a>
 <section class="section--control">
 <div class="container">
     <div class="row">

--- a/page-enterprise.php
+++ b/page-enterprise.php
@@ -197,7 +197,7 @@
 
 <!--<div class="separator"></div>
 
-<a name="security" id="security"></a>
+<a id="security"></a>
 <section class="section--security">
 	<div class="container">
 		<h2 class="text-center"><?php echo $l->t('Security');?></h2>
@@ -213,7 +213,7 @@
 </section>
 
 <div class="separator"></div>
-<a name="compliance" id="compliance"></a>
+<a id="compliance"></a>
 <section class="section--compliance">
 	<div class="container">
         <h2 class="text-center"><?php echo $l->t('Compliance');?></h2>
@@ -230,7 +230,7 @@
 
 <div class="separator"></div>
 
-<a name="scalability" id="scalability"></a>
+<a id="scalability"></a>
 <section class="section--scalability">
 	<div class="container">
 		<h2 class="text-center"><?php echo $l->t('Scalability');?></h2>
@@ -248,7 +248,7 @@
 
 <div class="separator"></div>
 
-<a name="reliability" id="reliability"></a>
+<a id="reliability"></a>
 <section class="section--reliability">
 	<div class="container">
 		<h2 class="text-center"><?php echo $l->t('Reliability');?></h1>
@@ -268,7 +268,7 @@
 <?php require get_template_directory().'/verticals.php';?>
 
 
-<a name="capabilities" id="capabilities"></a>
+<a id="capabilities"></a>
 <section class="section--whitepaper">
     <div class="container">
         <h3 class="section--intro text-center"><?php echo $l->t('What you need');?></h3>

--- a/page-events.php
+++ b/page-events.php
@@ -433,7 +433,7 @@ require(["require.config"], function() {
                 </tr>
             </table>
             </div>
-            <a name="ts" id="ts"></a>
+            <a id="ts"></a>
             <h2>Travel support</h2>
             <p class="section--paragraph"><?php echo $l->t('For the Conference, the Contributor Week and some events where we can use the help of some volunteers, we offer travel support. With this program, we cover 80% of your travel and hotel costs for a conference, and ask you to volunteer at the event. Please note that we can only offer travel support to a limited amount of our community members, so keep in mind that if we help cover your costs, the costs of another community member who may need it more than you can\'t be covered - only request travel support if you need it! If you want travel support, fill in');?> <a href="https://cloud.nextcloud.com/apps/forms/7x6yQHNpZDbgC3EP"><?php echo $l->t('this form.');?></a></p>
 		</div>

--- a/page-factorgroup.php
+++ b/page-factorgroup.php
@@ -179,7 +179,7 @@
 </section>
 
 <section class="section--more">
-	<a name="more" id="more"></a>
+	<a id="more"></a>
 <div class="container-widest">
 	<h1 class="section--heading-1 section--text--center"><?php echo $l->t('Key capabilities.');?></h1>
     <div class="row">
@@ -421,7 +421,7 @@
 
 
 <section class="section--security">
-	<a name="security" id="security"></a>
+	<a id="security"></a>
 	<div class="container">
         <div class="row">
             <div class="col-md-6 image--floated image--feature new-img">
@@ -443,7 +443,7 @@
 </section>
 
 <section class="section--monitoring">
-    <a name="monitoring" id="monitoring"></a>
+    <a id="monitoring"></a>
     <div class="container">
         <div class="row">
             <div class="col-md-6 image--feature new-img">
@@ -476,7 +476,7 @@
 
 
 <section class="section--storage">
-	<a name="storage" id="storage"></a>
+	<a id="storage"></a>
 	<div class="container">
         <div class="row">
             <div class="col-md-6 image--feature">
@@ -584,7 +584,7 @@
 </section>
 
 <section class="section--more">
-	<a name="more" id="more"></a>
+	<a id="more"></a>
 <div class="container-widest">
 	<h1 class="section--heading-1 section--text--center"><?php echo $l->t('And much more.');?></h1>
     <div class="row">
@@ -686,6 +686,3 @@
 </div>
 </section>
 <?php require get_template_directory().'/overlay.php'; ?>
-
-
-

--- a/page-faq-old.php
+++ b/page-faq-old.php
@@ -61,7 +61,7 @@ See also the <a href="https://nextcloud.com/faq" target="_blank">Nextcloud Enter
 	<li><a href="#entcustomers">What customers does Nextcloud, Inc. have?</a></li>
 </ul>
 
-<a name="whatis"></a>
+<a id="whatis"></a>
 <h2>What is this Nextcloud thing? Why would I care?</h2>
 <p>Nextcloud is a file sharing server that puts the control and security of your own data back into your hands.</p>
 <p>Today, most people have their digital life stored on online servers from various companies. Think Google, Apple, Facebook, Twitter, Dropbox, Instagram and many others. You uploaded your pictures, your music, your daily ramblings, happy and sad thoughts. You use these services to share with others, to send and receive emails, store address books, play music and video, have your files available on any device you want. All great features, no doubt! When your phone breaks, just having to log in to the new one to find all your pictures, contacts and other settings is an amazing and reassuring capability brought by these services, often (perhaps incorrectly) called 'the cloud'.</p>
@@ -83,7 +83,7 @@ See also the <a href="https://nextcloud.com/faq" target="_blank">Nextcloud Enter
 		</div>
 <h2>Running Nextcloud</h2>
 
-<a name="install"></a>
+<a id="install"></a>
 <h3>Where do I find information on how to use/install Nextcloud?</h3>
 <ul>
 	<li>You should start with the <a href="https://doc.nextcloud.org" target="_blank">Nextcloud Documentation</a></li>
@@ -91,14 +91,14 @@ See also the <a href="https://nextcloud.com/faq" target="_blank">Nextcloud Enter
 	<li>The Nextcloud forums have a <a href="https://forum.nextcloud.org/viewforum.php?f=17" target="_blank">special FAQ page</a> where each topic corresponds to typical mistakes or frequently occurring issues</li>
 </ul>
 
-<a name="channels"></a>
+<a id="channels"></a>
 <h3>I have a problem, what do I do?</h3>
 <ul>
 	<li>If the <a href="https://doc.nextcloud.org" target="_blank">Nextcloud Documentation</a> does not help and <a href="https://www.google.com/search?q=nextcloud+installation+problem" target="_blank">Google</a> can't solve your problem either you should check out <a href="/support/">our support page</a>.</li>
 	<li>If you are using Nextcloud in a business, educational setting or other professional or large scale deployments, note that the <a href="#entcomparison">Nextcloud, Inc.</a> offers support contracts as well as <a href="http://nextcloud.com/resources">resources</a> like white papers, webinars and a knowledge base to help successfully deploy and use Nextcloud in your business.</li>
 </ul>
 
-<a name="chat"></a>
+<a id="chat"></a>
 <h3>Where can I discuss ideas with other Nextcloud users?</h3>
 The best places for conversation are:
 <ul>
@@ -109,7 +109,7 @@ The best places for conversation are:
 <p>Note that <a href="https://nextcloud.org/blog/introducing-bounty-source-for-nextcloud/">Bountysource</a> offers a way of backing feature requests with your wallet.</p>
 <p>If you want to connect with other Nextcloud users and enthusiasts, check out our <a href="/promote">social media channels</a>.
 
-<a name="upgrade"></a>
+<a id="upgrade"></a>
 <h3>I want to upgrade my Nextcloud installation to the new release, how do I do that?</h3>
 <ul>
 	<li>The manual upgrade process is described in the <a href="<?php echo $DOCUMENTATION_ADMIN; ?>/maintenance/upgrade.html" target="_blank">Nextcloud Documentation</a>.</li>
@@ -117,26 +117,26 @@ The best places for conversation are:
 	<li>The built in Update app will usually have new Nextcloud releases available for upgrade some time in the week after a major release.</li>
 </ul>
 
-<a name="upgradeyet"></a>
+<a id="upgradeyet"></a>
 <h3>Is it safe to upgrade to the new release?</h3>
 <p>All code entering Nextcloud has been reviewed twice as well as tested by both automated means and through the efforts of volunteers. Releases are done only when all issues we are aware of are fixed or can be mitigated easily. In short, Nextcloud releases are always as stable as we could make it without <em>your</em> help. If you want the guarantee that it will work in your specific situation, <a href="<?php echo $DOCUMENTATION_DEVELOPER; ?>testing">make sure you help test before a release is made</a> so your issue can be fixed in time.</p>
 <p><strong>Why do we need your testing?</strong></p>
 <p>In short: because Nextcloud is <em>yours</em>. Nextcloud is an <a href="http://en.wikipedia.org/wiki/Open_source">Open Source</a> product, following an open development model. That means that many different stakeholders, both commercial and private, contribute to its development and share responsibility for the final release. Nextcloud is thus neither owned nor controlled by any single entity.</p>
 <p>By using Nextcloud, <em>you become part of the Nextcloud community</em>, sharing both ownership and responsibility for the product we collectively develop. Compare it to your responsibility for the functioning of your car: you regularly have to test it, or hire a garage for a checkup. It is yours, isn't it?</p>
 
-<a name="decentralization"></a>
+<a id="decentralization"></a>
 <h3>If I have my Nextcloud server hosted, does that still help me protect my privacy?</h3>
 <ul>
 	<li>Yes, it does. Decentralization helps protect your data by making it harder for an attacker to find, and less valuable if they do (decreasing motivation). Moreover, you get to choose where and with whom you host your data - so you can find a jurisdiction which protects you better, or host your data at a local company you trust. See <a href="https://nextcloud.org/blog/dont-be-caught-naked-in-the-cloud-decentralization-protects-our-data/" target="_blank">this blog post</a> for more details on this.</li>
 </ul>
 <h2>Technology</h2>
-<a name="rsync"></a>
+<a id="rsync"></a>
 <h3>Why does Nextcloud use csync rather than rsync?</h3>
 <ul>
 	<li>rsync is a one-way syncing protocol. This means that if you have two servers and delete a file on one side, it will pop up again if you use rsync. To ensure old files get removed but new files added, and updated files overwritten, you need a N-to-N sync solution. Nextcloud uses csync for syncing, which also deals with conflicts in a smart way.</li>
 </ul>
 
-<a name="language"></a>
+<a id="language"></a>
 <h3>Why is Nextcloud Server written in PHP?</h3>
 Nextcloud is for everybody. We picked PHP because:
 <ul>
@@ -146,25 +146,25 @@ Nextcloud is for everybody. We picked PHP because:
 In short, PHP lowers the barrier for using, auditing, modifying and contributing to Nextcloud. And that is important!<br />
 See more details in <a href="https://nextcloud.org/blog/nextcloud-and-php/" target="_blank">this blog about Nextcloud and PHP</a>.
 
-<a name="protocol"></a>
+<a id="protocol"></a>
 <h3>Why do you use HTTP and not another protocol?</h3>
 <ul>
 	<li>HTTP goes through every firewall and proxy.</li>
 </ul>
 
-<a name="android"></a>
+<a id="android"></a>
 <h3>Why does the calendar/contacts app not work with Android?</h3>
 <ul>
 	<li>iOS has native ical/caldav support, Android does not. You have to use an Android app that does but unfortunately almost all apps we're aware of that support caldav/ical are paid. One open source client is <a href="https://github.com/rfc2822/davdroid" target="_blank">DAVdroid</a>. You can find a list of <a href="https://github.com/nextcloud/core/wiki/Apps" target="_blank">3rd-party apps which work with Nextcloud here</a>.</li>
 </ul>
 
-<a name="mobilefeatures"></a>
+<a id="mobilefeatures"></a>
 <h3>Why does the Android/iOS mobile app not support my favorite feature?</h3>
 <ul>
 	<li>The Android mobile app has automatic picture and video upload. Both mobile clients give access to your files and include selective sync for keeping some of your files up to date on the device. Other features are under development or provided by other apps (like calendar and contacts, see <a href="#android">previous FAQ item</a>). If you'd like to add features to the Android or iOS client, find the <a href="https://github.com/nextcloud/android/" target="_blank">Android sources here</a> and the <a href="https://github.com/nextcloud/ios" target="_blank">iOS sources here</a>. Legal notes: the Android app is under the GPLv2, the iOS app under the GPLv3. To contribute to either, you have to <a href="https://nextcloud.org/contribute/agreement/" target="_blank">sign a contributor agreement</a> or contribute your code under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>. For testing, we provide a <a href="https://nextcloud.org/contribute/iOS-license-exception/" target="_blank">iOS license exception</a> so you can run the iOS app on up to 100 devices.</li>
 </ul>
 
-<a name="calendarcontacts"></a>
+<a id="calendarcontacts"></a>
 <h3>Why are Calendar and Contacts (or another app) not shipped with the zip file, are they not part of Nextcloud?</h3>
 <p>We have four types of apps: Core, Official, Approved and Experimental. To keep the official zip file of a reasonable size, we only ship the core functionality. Other apps are, however, just one click away!</p>
 <p>This is what the four categories mean:
@@ -176,7 +176,7 @@ See more details in <a href="https://nextcloud.org/blog/nextcloud-and-php/" targ
 </ul></p>
 <p>Changes of status can happen following <a href="<?php echo $DOCUMENTATION_DEVELOPER; ?>general/publishing">the rules documented here</a>. In simple words, the better maintained an app is, the more fitting an '<strong>official</strong>' label is. If a company, be it Nextcloud, Inc. due to customer demand, or another company, decides to dedicate resources to maintaining an app, it could become part of core. Your help thus matters!</p>
 
-<a name="security"></a>
+<a id="security"></a>
 <h3>How Secure is Nextcloud?</h3>
 <ul>
 	<li>Nextcloud supports HTTPS and offers server-side encryption. Nextcloud Server automatically generates a 4096-bit strong private/public key-pair for each user. Private keys are encrypted with the user’s login password and thus nobody can get at your data if you are not logged in on your Nextcloud server.</li>
@@ -184,7 +184,7 @@ See more details in <a href="https://nextcloud.org/blog/nextcloud-and-php/" targ
 	<li>To learn a bit more about Nextcloud security, watch <a href="https://www.youtube.com/watch?v=iLJbMrLgowk&index=25&list=PLtZe22ggl2YCfEzrHbFCylXGLGYtsHm96" target="_blank">this technical talk at the Nextcloud Contributor Conference</a> and read <a href="https://nextcloud.org/blog/how-nextcloud-uses-encryption-to-protect-your-data/" target="_blank">this article about Nextcloud and encryption</a>.</li>
 </ul>
 
-<a name="security2"></a>
+<a id="security2"></a>
 <h3>Does the long list of security advisories mean Nextcloud is less secure than other solutions?</h3>
 Rather the opposite. It signals that Nextcloud is a mature project taking responsibility for its security.
 <ul>
@@ -193,20 +193,20 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 	<li>No other open source file sync and share receives the scrutiny and security attention Nextcloud has. While a lower or higher number of CVE's does not directly say anything about security by itself, issuing CVE's is part of widely accepted responsible vendor security practice.</li>
 </ul>
 
-<a name="encryption"></a>
+<a id="encryption"></a>
 <h3>Are files encrypted during sync?</h3>
 <ul>
 	<li>Yes, we use TLS for sending and receiving files over the network so they are encrypted during transmission.</li>
 </ul>
 
-<a name="encryption2"></a>
+<a id="encryption2"></a>
 <h3>Does Nextcloud support file encryption on the server?</h3>
 <ul>
 	<li>Yes, but the Encryption app is designed to protect your data on external storage, rather than on the server Nextcloud runs on. In the current design, the server always has the keys to the data. They are encrypted by your password, but you can't trust that it is as secure as client-side encryption. Nextcloud does not do client-side encryption because you can not have a web interface if the server can't read the files and the web interface (and sharing abilities!) are very central to Nextcloud. So you will always need to be able to trust the server if you want to 'own' your data. Read more <a href="https://nextcloud.org/blog/how-nextcloud-uses-encryption-to-protect-your-data/" target="_blank">in this article</a>.</li>
 	<li>If you really want client-side encryption, we recommend you look for other solutions. Of course, if you are sufficiently knowledgeable and skilled, you would be more than welcome to improve on the file encryption technology. If you are interested in supporting or working on this feature, check out <a href="https://github.com/nextcloud/mirall/issues/275" target="_blank">github</a> for the latest state on the discussion about it and check out <a href="/contribute/" target="_blank">nextcloud.org/contribute</a> to get started.</li>
 </ul>
 
-<a name="backup"></a>
+<a id="backup"></a>
 <h3>Can I use Nextcloud as a backup solution?</h3>
 <p>No, Nextcloud is absolutely not a backup solution:
 <ul>
@@ -216,25 +216,25 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 </ul>
 <p>You should use a backup application to store the files in Nextcloud somewhere. The <a href="https://doc.nextcloud.org">Nextcloud documentation</a> has tips on how to back up Nextcloud.</p>
 
-<a name="conflict"></a>
+<a id="conflict"></a>
 <h3>Why do I sometimes get conflict files and messages while syncing?</h3>
 <ul>
 	<li>A conflict may be caused by two or more users editing the same files at the same time or while on the road before the files are synced. We do not merge changes to files like version control systems like git do; we don't modify user files, ever. So you will get two files, the one that was synced to the server first and the one you had locally modified in the same time. You can compare the file changes by hand and delete the local file once you're sure you did not lose data.</li>
 </ul>
 
-<a name="partialsyncing"></a>
+<a id="partialsyncing"></a>
 <h3>Does Nextcloud use delta-sync (only syncing file changes)?</h3>
 <ul>
 	<li>We introduced chunked, parallel up- and download with Nextcloud 7 and the Nextcloud 1.6 client. Syncing only file changes needs much deeper changes. It is on our roadmap, but won't be done soon. Find some <a href="https://dragotin.wordpress.com/2015/02/09/incremental-sync-in-nextcloud/" target="_blank">background on that decision here</a>. If you want to speed up the development of this feature by working on it, see <a href="https://github.com/nextcloud/mirall/issues/179" target="_blank">the github discussion</a>. If you really want this feature and would like to specifically fund work on it, see <a href="https://www.bountysource.com/issues/905030-sync-only-the-file-change-not-entire-file" target="_blank">the Bountysource page</a>.</li>
 </ul>
 
-<a name="deduplication"></a>
+<a id="deduplication"></a>
 <h3>Does Nextcloud do file de-duplication?</h3>
 <ul>
 	<li>No, we think that that is the job of the file system. We do maintain versions of files as they are replaced and you may revert to older versions at any time.</li>
 </ul>
 
-<a name="syncspeed"></a>
+<a id="syncspeed"></a>
 <h3>Why is Nextcloud syncing not faster?</h3>
 <ul>
 	<li>The design of Nextcloud is constrained by two important features: scalability and reliability.
@@ -245,7 +245,7 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 	This does not mean there is no room for improvement, we work very hard to make Nextcloud faster and every release introduces many performance improvements. Also, help is always welcome. Check out the <a href="https://github.com/nextcloud/mirall/" target="_blank">client code on github</a> if you are interested in the challenges of fast, scalable and reliable file syncing! See <a href="/contribute/" target="_blank">the contribute pages</a> for more information about getting involved.</li>
 </ul>
 
-<a name="scaling"></a>
+<a id="scaling"></a>
 <h3>Does Nextcloud scale to large deployments?</h3>
 <ul>
 	<li>Nextcloud can run on Raspberry Pi like development boards but is certainly not limited to low-end hardware. Worlds' largest on-premises cloud deployment services <a href="https://nextcloud.com/sciebo-germanys-largest-cloud-project-500000-users-launches-today/" target="_blank">500,000 students on Nextcloud</a> and terabytes of data are shared through Nextcloud at organizations like the  <a href="http://cernbox.web.cern.ch/" target="_blank">atom smashers at CERN</a>. Nextcloud founder Frank Karlitschek wrote a <a href="http://karlitschek.de/2015/03/scaling/" target="_blank">post about the scalability of Nextcloud</a>.</li>
@@ -255,42 +255,42 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 	<li>Check out the <a href="https://github.com/nextcloud/core/" target="_blank">core code on github</a> if you are interested in the challenges of fast, scalable and reliable file syncing! See <a href="/contribute/">the contribute pages</a> for more information about getting involved.</li>
 </ul>
 
-<a name="notcrippled"></a>
+<a id="notcrippled"></a>
 <h3>Is Nextcloud Server limited to a certain number of users or files and do I have to purchase something to get a 'full' version?</h3>
 <p>Nextcloud is open source, so artificial limitations have no place in it. It can sustain the same number of users, downloads or data as a version equipped with enterprise apps and a support contract.</p>
 
 <h2>Nextcloud Community</h2>
-<a name="communitylocation"></a>
+<a id="communitylocation"></a>
 <h3>Where is the Nextcloud community hosted?</h3>
 <ul>
 	<li>The Nextcloud code can be found at <a href="https://github.com/nextcloud" target="_blank">github.com/Nextcloud</a> and our website is on <a href="https://nextcloud.org" target="_blank">nextcloud.org</a></li>
 </ul>
 
-<a name="communitysize"></a>
+<a id="communitysize"></a>
 <h3>How big is the Nextcloud Community?</h3>
 <ul>
 	<li>Nextcloud has an estimated <a href="https://nextcloud.org/blog/nextcloud-grows-to-8-million-users/" target="_blank">8 million users</a> and over 350 programmers contributed code in the last 12 months. Tens of thousands participate on our forums, mailing lists, translation and documentation tools, and IRC channels in testing, discussions, translation, documentation and so on. See <a href="http://blog.jospoortvliet.com/2014/08/nextcloud-numbers.html" target="_blank">this blog</a> for an analysis and dig into the statistics <a href="https://nextcloud.org/blog/announcing-nextcloud-community-statistics-provided-by-bitergia/" target="_blank">on Bitergia</a> so you can judge the health of our community yourself. We track the development of the Nextcloud user and contributor base on <a href="/history">our history page</a>.</li>
 </ul>
 
-<a name="howitstarted"></a>
+<a id="howitstarted"></a>
 <h3>How did Nextcloud get started?</h3>
 <ul>
 	<li>Nextcloud started with a keynote by Frank Karlitschek at Camp KDE’10 where he talked about the need for a self-controlled free and open source cloud. Two years later, Frank announced the start of Nextcloud, Inc. which is headquartered in Lexington, Massachusetts in the United States and Nuremburg, Germany. Find out more on <a href="/contribute/" target="_blank">our history page</a>.</li>
 </ul>
 
-<a name="getinvolved"></a>
+<a id="getinvolved"></a>
 <h3>How can I get involved in the Nextcloud Community?</h3>
 <ul>
 	<li>The best way to get started is to visit <a href="/contribute/" target="_blank">nextcloud.org/contribute</a>.</li>
 </ul>
 
-<a name="notechknowledge"></a>
+<a id="notechknowledge"></a>
 <h3>But what if I'm not very technical?</h3>
 <ul>
 	<li>There are lots of ways you can contribute to Nextcloud. We have a need for developers, designers, event organizers, speakers, QA and more. It is all <a href="/contribute/" target="_blank">on the <em>contribute</em> page</a>!</li>
 </ul>
 
-<a name="mobile"></a>
+<a id="mobile"></a>
 <h3>How can I get started writing mobile (Android, iOS) clients or third party (web) apps?</h3>
 <ul>
 	<li>First of all, awesome you want to bring Nextcloud support to your app or build an app entirely for Nextcloud, rocking!</li>
@@ -298,7 +298,7 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 	<li>To build a third party application accessing Nextcloud data through its external API, <a href="<?php echo $DOCUMENTATION_DEVELOPER; ?>core/ocs-share-api.html">find the documentation here</a>.
 </ul>
 
-<a name="appslocation"></a>
+<a id="appslocation"></a>
 <h3>Where can I find Nextcloud apps?</h3>
 <ul>
 	<li>There is a large selection of built in and community-approved apps available for download from within the App management screen in your Nextcloud installation. Featuring apps like the Music app, the Calendar app and so on you can watch your movies, share your pictures and keep your bookmarks synced. Download is seamless (just 'enable' the app and wait while it is downloaded, installed and enabled) and upgrading is easy from the same screen.</li>
@@ -307,7 +307,7 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 	<li>Building a new Nextcloud app is easy. If you're interested in developing your own Nextcloud app, see <a href="/contribute/" target="_blank">the contribute page</a>, where you can find a link to the latest App Development documentation.</li>
 </ul>
 
-<a name="communityswag"></a>
+<a id="communityswag"></a>
 <h3>Where can I find Nextcloud t-shirts, stickers and other swag?</h3>
 <ul>
 	<li>Nextcloud has a store on <a href="http://www.cafepress.com/nextcloudshop" target="_blank">this page</a> where you can find posters, mugs, stickers, magnets, buttons, t-shirts and much more.</li>
@@ -317,7 +317,7 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 <h2>Legal</h2>
 <p>DISCLAIMER: The answers below are general directions, <em>not</em> legal advice and we can not provide such. Contact a lawyer if you are unsure about any of this.</p>
 
-<a name="modifynextcloud"></a>
+<a id="modifynextcloud"></a>
 <h3>Can I modify Nextcloud and run it on my website for others to use/access?</h3>
 <p>Nextcloud Server is available <a href="http://www.gnu.org/licenses/agpl-3.0.html" target="_blank">under the AGPLv3</a>. In laymen terms (this is NOT legal advice!) the AGPL license grants you the right to run the Nextcloud code wherever and however you want, make modifications and additions and share these with anybody you like. The only limitation is that if you give others access to your Nextcloud (by giving them a user account or sharing files with them), you must also give them access to the source code; and the whole source (including your modifications) has to be under the AGPLv3 license.</p>
 <p><strong>How to comply</strong></p>
@@ -331,41 +331,41 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 <li>If you use Nextcloud yourself (as private user or company!) and do not give third parties access to its user interface or API's (like webDAV), the AGPLv3 sharing clause does not come into effect. In general, note that you are only ever obliged to share the original source <em>upon request</em> with a third party who has been given <em>access to your Nextcloud instance</em>. You must merely make sure that users are aware of this right.</li>
 </ul>
 
-<a name="closedapps"></a>
+<a id="closedapps"></a>
 <h3>Can I write closed source or proprietary apps for Nextcloud Server?</h3>
 <ul>
 	<li>Yes, but following the requirements of the <a href="http://www.gnu.org/licenses/agpl-3.0.html" target="_blank">under the AGPLv3</a>, these can be distributed or made available to users outside of your household or organization only under the <a href="https://www.nextcloud.com" target="_blank">Nextcloud Enterprise Edition</a>, which supports integration with proprietary technologies. Contact <a href="https://nextcloud.com/contact/"target="_blank">Nextcloud, Inc.</a> for details.</li>
 	<li>External apps like mobile or desktop clients (like those using the <a href="https://github.com/nextcloud/ios-library">iOS</a> or <a href="https://github.com/nextcloud/android-library">Android</a> Nextcloud libraries, <a href="https://nextcloud.com/nextcloud-open-sources-mobile-libraries/">which are MIT licensed</a>) or apps running on another server and otherwise not part of Nextcloud but using the external Nextcloud OCS API as <a href="<?php echo $DOCUMENTATION_DEVELOPER; ?>/core/externalapi.html" target="_blank">you would find here</a> are NOT subject to the AGPLv3 and can be under any license you like.</li>
 </ul>
 
-<a name="copyrightviolation"></a>
+<a id="copyrightviolation"></a>
 <h3>I want to report a copyright infringement or other legal matter on a site that mentions use of Nextcloud.</h3>
 <ul>
 	<li>Nextcloud is an open-source project that can be easily hosted by any person allowing anybody to securely exchange files. Neither the Nextcloud open source project nor Nextcloud, Inc. exert any legal or technical control over those domains. If you found a copyright infringement on a domain other than <a href="http://nextcloud.org" target="_blank">nextcloud.org</a> or <a href="http://nextcloud.com" target="_blank">nextcloud.com</a>, please try to contact the domain owner. Nextcloud has no insight or control over Nextcloud instances.</li>
 </ul>
 
-<a name="trademark"></a>
+<a id="trademark"></a>
 <h3>Can I use the Nextcloud logo on my website, for my Nextcloud app or client, or promotional materials?</h3>
 <ul>
 	<li>The use of the Nextcloud trademark is governed by <a href="/trademarks">our trademark policy</a>. In short, we want to support you in promoting, using and building on Nextcloud but we also want to prevent confusion about the meaning of our logo and trademark and your use of it. Carefully read <a href="/trademarks">our trademark policy</a> before you use Nextcloud marks (like our logo or our name) on a website, app, flyer or anywhere else.</li>
 </ul>
 
 <h2>Nextcloud for professional use</h2>
-<a name="professionaluse"></a>
+<a id="professionaluse"></a>
 <h3>Can I use Nextcloud in professional, large scale deployments?</h3>
 <ul>
 	<li>Absolutely. Nextcloud Server is built for and used by both private and large scale, professional deployments in enterprises, education, research institutions and government agencies. Find some of the bigger deployments among the <a href="https://nextcloud.com/customer-stories" target="_blank">Nextcloud.com customer stories</a>.</li>
 	<li>You can use Nextcloud for free in any situation - due to the open source license. However, if you require support and certain enterprise functionality, consider <a href="#entcomparison">purchasing a subscription</a>.</li>
 </ul>
 
-<a name="professionaluse"></a>
+<a id="professionaluse"></a>
 <h3>What resources exist to support my deployment?</h3>
 <ul>
 	<li>Where home users can find <a href="#channels">the support resources they need</a> in the community, professional users can find <a href="http://nextcloud.com/resources" target="_blank">resources developed by Nextcloud, Inc.</a> as well as the <a href="https://nextcloud.com/get-started-standard-subscription" target="_blank">Standard Subscription</a> support option for Nextcloud Server and the <a href="https://nextcloud.com/products/enterprise" target="_blank">Enterprise Subscription</a> which adds functionality for integrating Nextcloud in an enterprise infrastructure.
 	<li>You can find out where to look for relevant resources on <a href="/support" target="_blank">this page</a>.</li>
 </ul>
 
-<a name="entcomparison"></a>
+<a id="entcomparison"></a>
 <h3>What is the Standard Subscription and Enterprise Subscription?</h3>
 <ul>
 	<li>Professional deployments of Nextcloud Server only interested in enterprise file sync and share can benefit from the enterprise service and support offered by Nextcloud, Inc. through the <a href="https://nextcloud.com/get-started-standard-subscription" target="_blank">Standard Subscription.</a></li>
@@ -373,7 +373,7 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 	<li>You can find a comparison table <a href="https://nextcloud.com/subscriptions/" target="_blank">detailing support options here</a> and enterprise features on <a href="https://nextcloud.com/lp/nextcloud-server-or-enterprise-edition/" target="_blank">this page</a>.</li>
 </ul>
 
-<a name="bestedition"></a>
+<a id="bestedition"></a>
 <h3>Which solution is best for me?</h3>
 <ul>
 	<li>As home or small business user, you benefit from the rich functionality of the Nextcloud Server. The documentation as well as <a href="#channels">community support</a> or support through IT service providers are best suited for your use case.</li>
@@ -382,7 +382,7 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 	<li><a href="http://vimeo.com/107631039" target="_blank">Watch the Community and Enterprise Edition Webinar</a> to find out what is best for you.</li>
 </ul>
 
-<a name="communityandenterprise"></a>
+<a id="communityandenterprise"></a>
 <h3>How do the community and company work together?</h3>
 <ul>
 	<li>The company makes it possible for developers to work full time on Nextcloud, organizing Nextcloud events, marketing Nextcloud to a wider audience and supporting companies, governments and schools in their Nextcloud deployments.</li>
@@ -391,9 +391,8 @@ Rather the opposite. It signals that Nextcloud is a mature project taking respon
 </ul>
 Check out <a href="https://nextcloud.com" target="_blank">nextcloud.com</a> and <a href="/history" target="_blank">nextcloud.org/history</a> for more information.
 
-<a name="entcustomers"></a>
+<a id="entcustomers"></a>
 <h3>What customers does Nextcloud, Inc. have?</h3>
 <ul>
 	<li>Nextcloud works with several large enterprises across financial services, energy, government, healthcare, education and more. Some of our marquis customers include TU Berlin, CERN, Joy Global, Wind River, Jefferson National, Geant, De'Longhi, TTX, Dutch Ministry of Defense as well as other large financial services and telco companies we cannot name. Check out the <a href="https://nextcloud.com/customer-stories/" target="_blank">nextcloud customer stories</a> for more customers and their testimonials.</li>
 </ul>
-

--- a/page-faq.php
+++ b/page-faq.php
@@ -43,7 +43,7 @@
 </section>
 
 <section class="section--faq">
-<a name="faq" id="faq"></a>
+<a id="faq"></a>
 <div class="container-fluid">
 			<div class="text-center">
 				<h1><?php echo $l->t('Frequently asked questions');?></h1>

--- a/page-files.php
+++ b/page-files.php
@@ -89,7 +89,7 @@
 </section>
 
 <section class="section--collaboration quote">
-    <a name="collaboration" id="collaboration"></a>
+    <a id="collaboration"></a>
 	<div class="container">
         <div class="row">
             <div class="col-md-6  image--floated">
@@ -140,7 +140,7 @@
 </section>
 
 <section class="section--workflow">
-	<a name="workflow" id="workflow"></a>
+	<a id="workflow"></a>
 	<div class="container">
         <div class="row">
             <div class="col-md-6">
@@ -187,7 +187,7 @@
 	</div>
 </section>
 
-<a name="send" id="send"></a>
+<a id="send"></a>
 <section class="section--sharing">
     <div class="container">
         <div class="row">
@@ -209,7 +209,7 @@
 <?php require get_template_directory().'/compliance.php';?>
 
 <section class="section--clients">
-	<a name="clients" id="clients"></a>
+	<a id="clients"></a>
 	<div class="container">
         <div class="row">
             <div class="col-md-6 image--feature">
@@ -227,7 +227,7 @@
 </section>
 
 
-<a name="integrations" id="integrations"></a>
+<a id="integrations"></a>
 <section class="section--outlook quote">
 <div class="container">
     <div class="featurerow">

--- a/page-government.php
+++ b/page-government.php
@@ -215,7 +215,7 @@ require(["require.config"], function() {
     </div>
 </section>
 
-<a name="convenient"></a>
+<a id="convenient"></a>
 <section class="section--convenient">
 	<div class="container">
         <div class="row">
@@ -280,7 +280,7 @@ require(["require.config"], function() {
 </section>
 
 
-<a name="secure"></a>
+<a id="secure"></a>
 <section class="section--secure">
 <div class="container">
     <div class="row">
@@ -360,7 +360,7 @@ require(["require.config"], function() {
 </div>
 </section>
 
-<a name="integrated"></a>
+<a id="integrated"></a>
 <section class="section--integrated">
 <div class="container">
     <div class="row">

--- a/page-groupware.php
+++ b/page-groupware.php
@@ -301,7 +301,7 @@
 	</div>
 </section>
 
-<a name="pricing">
+<a id="pricing">
 <section class="section--contact quote">
 <div class="container">
     <div class="row">

--- a/page-healthcare.php
+++ b/page-healthcare.php
@@ -126,7 +126,7 @@ require(["require.config"], function() {
 <?php require get_template_directory().'/onpremises.php';?>
 
 
-<a name="convenient"></a>
+<a id="convenient"></a>
 <section class="section--convenient">
 	<div class="container">
         <div class="row">
@@ -197,7 +197,7 @@ require(["require.config"], function() {
 </div>
 </section>
 
-<a name="secure"></a>
+<a id="secure"></a>
 <section class="section--secure">
 <div class="container">
     <div class="row">
@@ -299,7 +299,7 @@ require(["require.config"], function() {
 
 
 
-<a name="integrated"></a>
+<a id="integrated"></a>
 <section class="section--integrated">
 <div class="container">
     <div class="row">
@@ -404,7 +404,7 @@ require(["require.config"], function() {
 </section>
 
 <div class="separator"></div>
-<a name="HIPAA"></a>
+<a id="HIPAA"></a>
 <section class="section--hipaa">
 <div class="container">
     <div class="row">

--- a/page-homepage.php
+++ b/page-homepage.php
@@ -41,7 +41,7 @@
 		selector.style.opacity = 0;
 	})
 </script>
-<a name="scroll"></a>
+<a id="scroll"></a>
 
 <section class="section--intro">
 <div class="container">
@@ -96,7 +96,7 @@
 </div>
 </section>
 
-<a name="why-nextcloud"></a>
+<a id="why-nextcloud"></a>
 <section id="why-nextcloud" class="section--why">
 	<div class="container">
 		<h1 class="section--heading-1 text-center"><?php echo $l->t('Why Nextcloud?');?></h1>

--- a/page-hub.php
+++ b/page-hub.php
@@ -136,7 +136,7 @@
 </section>
 
 <section class="section--more">
-	<a name="more" id="more"></a>
+	<a id="more"></a>
 <div class="container-widest">
 	<h1 class="section--heading-1 section--text--center"><?php echo $l->t('Key capabilities.');?></h1>
     <div class="row">
@@ -479,7 +479,7 @@
 
 
 <section class="section--security">
-	<a name="security" id="security"></a>
+	<a id="security"></a>
 	<div class="container">
         <div class="row">
             <div class="col-md-6 image--floated image--feature new-img">
@@ -501,7 +501,7 @@
 </section>
 
 <section class="section--monitoring">
-    <a name="monitoring" id="monitoring"></a>
+    <a id="monitoring"></a>
     <div class="container">
         <div class="row">
             <div class="col-md-6 image--feature new-img">
@@ -534,7 +534,7 @@
 </section>
 
 <section class="section--storage">
-	<a name="storage" id="storage"></a>
+	<a id="storage"></a>
 	<div class="container">
         <div class="row">
             <div class="col-md-6 image--feature">
@@ -736,7 +736,7 @@
 </section>
 
 <section class="section--more">
-	<a name="more" id="more"></a>
+	<a id="more"></a>
 <div class="container-widest">
 	<h1 class="section--heading-1 section--text--center"><?php echo $l->t('And much more.');?></h1>
     <div class="row">
@@ -838,6 +838,3 @@
 </div>
 </section>
 <?php require get_template_directory().'/overlay.php'; ?>
-
-
-

--- a/page-include.php
+++ b/page-include.php
@@ -171,7 +171,7 @@
             </div>
         </div>
     </div>
-    <a name="mentors" id="mentors"></a>
+    <a id="mentors"></a>
     <h1 class="section--heading-1 text-center">Mentors</h1>
     <div class="row">
         <div class="col-md-4">

--- a/page-install.php
+++ b/page-install.php
@@ -76,7 +76,7 @@
         <a class="hyperlink" href="https://apps.nextcloud.com" target="_blank" rel="tooltip" title="App Store"><?php echo $l->t('the Nextcloud app store.');?></a></p>
 		<p><a class="button button--blue eios" href="<?php echo home_url('enterprise') ?>"><?php echo $l->t('Enterprise support</a>');?></p></p>
 	</div>
-	<a name="testing"></a>
+	<a id="testing"></a>
 	<div class="col-md-4">
 		<hr class="narrow"></hr>
 		<div class="numbadge centre">

--- a/page-ionos.php
+++ b/page-ionos.php
@@ -155,7 +155,7 @@
 		</div>
 	</div>
 </section>
-<a name="order"></a>
+<a id="order"></a>
 <section class="section--form">
 <div class="container">
     <div class="row">

--- a/page-nextcloud-vs-office365.php
+++ b/page-nextcloud-vs-office365.php
@@ -499,7 +499,7 @@
 
 
 
-<a name="integrated"></a>
+<a id="integrated"></a>
 <section class="section--integrated">
 <div class="container">
     <div class="row">

--- a/page-policy.php
+++ b/page-policy.php
@@ -24,7 +24,7 @@
         <li>Reproduction steps</li>
     </ul>
     <p>A member of the security team will confirm the vulnerability, determine its impact, and develop a fix. The fix will be applied to the master branch, tested, and packaged in the next security release. The vulnerability will be publicly announced after the release. Finally, your name will be added to the <a href="/security/hall-of-fame">hall of fame</a> as a thank you from the entire Nextcloud community.</p>
-    <a name="policy"></a>
+    <a id="policy"></a>
     <h3>Responsible Disclosure Policy</h3>
     The Nextcloud community asks that you comply with the following guidelines when researching and reporting security vulnerabilities:
     <ul>

--- a/page-pr20200408.php
+++ b/page-pr20200408.php
@@ -58,7 +58,7 @@ jos.poortvliet<a href="mailto:pr@nextcloud.com">@nextcloud.com</a></p>
 <p>Matthias Damerow<br />
 Phone: +49 461 430 920 0<br />
 matthias.damerow<a href="https://mailto:marketing@viakom.de">@viakom.de</a></p>
-<a name="german"></a>
+<a id="german"></a>
 <h1>Deutsche Cloud-Spezialisten starten DSGVO-konforme Kollaborationsplattform für Schulen, Behörden und Mittelstand</h1>
 <p>So geht Homeschooling und Home Office datenschutzkonform und einfach: Nextcloud, IONOS und der Managed Service Provider Viakom bieten seit heute eine Kollaborations-Lösung an, die eine DSGVO-konforme und sichere Zusammenarbeit ermöglicht. Das Angebot richtet sich insbesondere an Schulen, Behörden sowie kleinere und mittelständische Unternehmen. Hinter der Lösung steht die Anwendung Nextcloud Hub, inklusive aller Funktionen, die Nutzer von einer modernen Kollaborationsplattform erwarten: Telefonie,  Chat- und Videokonferenzsystem, gemeinsame Dokumentenbearbeitung, ein Mailserver und -client sowie eine Aufgaben- und Kalenderverwaltung. Die Lösung ist über eine einfache mobile, Desktop- und Web-Oberfläche bedienbar. Sie wird in den deutschen IONOS Rechenzentren gehosted und von Viakom vertrieben und gem.</p>
 <p>Die DSGVO-konforme, vollständig verwaltete Lösung kann innerhalb von 24 Stunden implementiert werden. Im Gegensatz zu ausländischen SaaS-Lösungen haben die Anwender dank der Kooperation dreier deutscher Unternehmen keinerlei Datenschutzrisiken und Sicherheitslücken zu befürchten.</p>
@@ -103,4 +103,3 @@ matthias.damerow<a href="https://mailto:marketing@viakom.de">@viakom.de</a></p>
 </div>
 </div>
 </section>
-

--- a/page-pr20200519.php
+++ b/page-pr20200519.php
@@ -93,7 +93,7 @@
 <p>Jos Poortvliet<br />
 Phone: +49 (0) 171 121 7528<br />
 jos.poortvliet<a href="mailto:pr@nextcloud.com">@nextcloud.com</a></p>
-<a name="german"></a>
+<a id="german"></a>
 <h2>German version</h2>
 <h1>Talk 9: Großer Schritt vorwärts für Teamgespräche, effiziente Arbeitsabläufe und Open-Source-Backend</h1>
 <p><em>Neue Version macht das <strong>hochleistungsfähige Back-End Open Source verfügbar</strong>, verbessert die Skalierbarkeit, führt die Grid-Ansicht ein und erleichtert die gemeinsame Nutzung und Bearbeitung von Dokumenten</em></p>
@@ -167,4 +167,3 @@ jos.poortvliet<a href="mailto:pr@nextcloud.com">@nextcloud.com</a></p>
 </div>
 </div>
 </section>
-

--- a/page-pr20200603.php
+++ b/page-pr20200603.php
@@ -131,7 +131,7 @@
         <a href="https://nextcloud.com/media/new-password-policy-configuration.png"><img src="https://nextcloud.com/media/new-password-policy-configuration.png" alt="screenshot of the password policy configuration" class="img-responsive" /></a><br>The new password policy configuration
     </div>
 </div>
-<a name="german"></a>
+<a id="german"></a>
 <h1>Nextcloud Hub bringt Produktivität für Home-Office-Mitarbeiter</h1>
 <p><em>Die 19. Version von Nextcloud Hub bietet Remote-Mitarbeitern vollen Zugriff auf alle Teamressourcen und direkte Kommunikation, so dass Unternehmen ihre Produktivität steigern und gleichzeitig Sicherheit und Vertraulichkeit schützen können.</em></p>
 <p>Juni 2020 - Nextcloud, der Marktführer für On-Premises-Collaboration-Lösungen, setzt einen neuen Industriestandard und führt eine wichtige neue Version von Nextcloud Hub ein, die auf die Zusammenarbeit von Teams an verteilten Standorten abgestimmt ist, die bereits in Tausenden von großen und kleinen Unternehmen auf der ganzen Welt beschäftigt sind. Diese Version, die als “Home-Office” bezeichnet wird, bringt die Zusammenarbeit an Dokumenten in Video-Chats, vereinfacht die Authentifizierung erheblich und verbessert die Leistung.</p>
@@ -250,4 +250,3 @@ jos.poortvliet<a href="mailto:pr@nextcloud.com">@nextcloud.com</a></p>
 </div>
 </div>
 </section>
-

--- a/page-pr20210111.php
+++ b/page-pr20210111.php
@@ -76,7 +76,7 @@ Phone: +49 (0) 171 121 7528<br />
 </ul>
 
 
-<a name="german"></a>
+<a id="german"></a>
 <h1>Telekom und Nextcloud bieten Collaboration-Lösung</h1>
 <h3>    • Gemanagtes Angebot für Unternehmen in Europa<br />
     • Europäische Datensouveränität und DSGVO-Konformität im Mittelpunkt</h3>
@@ -137,6 +137,3 @@ Phone: +49 (0) 711 25 24 28 90<br />
 </div>
 </div>
 </section>
-
-
-

--- a/page-pr20210129.php
+++ b/page-pr20210129.php
@@ -56,7 +56,7 @@ Peter Ganten, CEO at Univention, said:
 
 <p>With UCS @ school, Univention offers a platform optimized for digital education with central identity management and the simple provision of services from third-party vendors, such as learning management systems, email, cloud and office applications for schools, school authorities and federal states via their own school portals. UCS and UCS @ school are used by a number of federal states, and a range of municipalities and districts, administrations and companies. For more information: <a href="https://www.univention.de">www.univention.de</a>.</p>
 
-<a name="german"></a>
+<a id="german"></a>
 
 <h1>Nextcloud, Open-Xchange und Univention kündigen Software-Suite für den öffentlichen Sektor an</h1>
 <h3>Führende Open-Source-Software-Unternehmen unterzeichnen Partnerschaftsvertrag für Entwicklung einer Branchenneuheit</h3>
@@ -115,6 +115,3 @@ Phone: +49 (0) 711 25 24 28 90<br />
 </div>
 </div>
 </section>
-
-
-

--- a/page-pr20210416.php
+++ b/page-pr20210416.php
@@ -48,7 +48,7 @@ Marketing Director<br />
 Phone: +49 (0) 171 121 7528<br />
 pr@nextcloud.com</p>
 
-<a name="german"></a>
+<a id="german"></a>
 
 <h1>Managed Nextcloud: IONOS startet professionellen Cloud-Speicher</h1>
 <h3>Vollständige Datensouveränität und deutscher Datenschutz / Managed-Betrieb ohne Administrationsaufwand / flexibel erweiterbar</h3>
@@ -84,6 +84,3 @@ pr@nextcloud.com</p>
 </div>
 </div>
 </section>
-
-
-

--- a/page-pr20210421.php
+++ b/page-pr20210421.php
@@ -55,7 +55,7 @@ Marketing Director<br />
 Phone: +49 (0) 171 121 7528<br />
 pr@nextcloud.com</p>
 
-<a name="german"></a>
+<a id="german"></a>
 
 <h1>Bundesregierung finanziert Open-Source Cloud für Patientendaten</h1>
 <p><em>Nextcloud App bietet Gegenentwurf zu der Masse an Lösungen, die sich durch den Verkauf von Gesundheitsdaten finanzieren</em></p>
@@ -100,6 +100,3 @@ pr@nextcloud.com</p>
 </div>
 </div>
 </section>
-
-
-

--- a/page-pr20210503.php
+++ b/page-pr20210503.php
@@ -60,7 +60,7 @@ Marketing Director<br />
 Phone: +49 (0) 171 121 7528<br />
 pr@nextcloud.com</p>
 
-<a name="german"></a>
+<a id="german"></a>
 
 <h1>Nextcloud und 8Soft starten Vertriebspartnerschaft</h1>
 <p><em>Nextcloud App bietet Gegenentwurf zu der Masse an Lösungen, die sich durch den Verkauf von Gesundheitsdaten finanzieren</em></p>
@@ -109,6 +109,3 @@ pr@nextcloud.com</p>
 </div>
 </div>
 </section>
-
-
-

--- a/page-pr20210826.php
+++ b/page-pr20210826.php
@@ -56,7 +56,7 @@ pr@nextcloud.com</p>
 <hr />
 
 
-<a name="german"></a>
+<a id="german"></a>
 <h1>Gaia-X beweist Unabhängigkeit von großen US-Tech-Anbietern und entscheidet sich für EU-basierte Kollaborationsplattform</h1>
 <p><em>Gaia-X fokussiert sich auf ihre ursprüngliche Mission und zeigt durch handfeste Ergebnisse ihre Unabhängigkeit von Hyperscalern</em></p>
 <p><em>Berlin, 26. August 202</em>1 - Nexcloud GmbH, das Unternehmen hinter der weltweit am häufigsten eingesetzten On-Premises Content Collaboration Plattform, gibt die Zusammenarbeit mit dem Gaia-X Projekt bekannt und ist nun die offizielle digitale Kollaborationsplattform für Gaia-X.</p>
@@ -97,6 +97,3 @@ pr@nextcloud.com</p>
 </div>
 </div>
 </section>
-
-
-

--- a/page-press.php
+++ b/page-press.php
@@ -56,7 +56,7 @@ height: 100px;
 
     <h2>Latest News and Annoucements</h2>
     <?php wp_get_archives( array( 'type' => 'postbypost', 'limit' => 5, 'format' => 'html' ) ); ?>
-<a name="logo"></a>
+<a id="logo"></a>
     <h2>Nextcloud Resources</h2>
     <!-- <p>Find an overview of Nextcloud history <a href="/history">on our history page</a> and an overview with <a href="/faq">frequently asked questions in our FAQ</a>.</p> -->
     <a href="<?php echo home_url('hub') ?>" class="button button--blue">Key Features of Nextcloud Hub</a>

--- a/page-pricing.php
+++ b/page-pricing.php
@@ -48,7 +48,7 @@
 </section>
 
 <section class="section--plans">
-<a name="plans" id="plans"></a>
+<a id="plans"></a>
 <div class="container">
 	<div class="row">
         <div class="col-md-8 col-md-offset-2">
@@ -220,7 +220,7 @@
 					<li class="ball" title="<?php echo $l->t('Contact us for a quote relevant for your specific market vertical.');?>" rel="tooltip"><?php echo $l->t('Additional pricing tiers are available up to millions of users');?></li>
 					<li class="ball" title="<?php echo $l->t('Contact us for a quote relevant for your specific market.');?>" rel="tooltip"><?php echo $l->t('Framework agreements available');?></li>
 				</div>
-				<a name="extracosts" id="extracosts"></a> <!--has to be here due to header-->
+				<a id="extracosts"></a> <!--has to be here due to header-->
 				<a class="button button--blue button--arrow button--large" href="<?php echo home_url('enterprise/buy') ?>" role="button" id="get-nextcloud-button"><?php echo $l->t('Request offer');?> <span class="icon-arrow"></span></a>
 			</div>
 		</div>
@@ -309,7 +309,7 @@
 </section>
 
 <section class="section--options">
-	<a name="options" id="options"></a>
+	<a id="options"></a>
 <div class="container-widest">
 	<div class="introduction">
 		<h1 class="section--heading-1 section--text--center "><?php echo $l->t('Fitting your needs');?></h1>
@@ -406,7 +406,7 @@
 </section>
 
 
-<a name="discounts" id="discounts"></a>
+<a id="discounts"></a>
 <div class="container discounts">
 	<div class="row">
 		<h1 class="header "><?php echo $l->t('Discounts');?></h1>

--- a/page-privacy.php
+++ b/page-privacy.php
@@ -117,7 +117,7 @@
             </ul>
             <h3><?php echo $l->t('Unsubscribing');?></h3>
             <p><?php echo $l->t('If at any time you would like to unsubscribe from receiving future emails follow the instructions at the bottom of each email and we will promptly remove you from correspondence by that tool. Note that you have to unsubscribe separately from our newsletter and our marketing automation tool.');?></p>
-            <a name="TOS"></a>
+            <a id="TOS"></a>
             <h3><?php echo $l->t('Discourse forums ToS');?></h3>
             <p><?php echo $l->t('If you wish to use our forums, you have to agree to the stipulations below.');?></p>
             <ul>

--- a/page-release-channels.php
+++ b/page-release-channels.php
@@ -89,7 +89,7 @@
         <p><?php echo $l->t('Note that releases don\'t show up in the updater app right away. We usually stagger releases out to watch the impact and hold off in case very serious problems pop up. In practice, most bugfix releases are available within a week, major releases to a proportion of the users on release day in the Stable channel; we will increase that percentage usually to 100% after the first bugfix release.Packages for the Release channels might be available in distributions, docker images, Snap and so on, this is up to the packagers and communities developing for those platforms.');?></p>
         <!--<p><strong>Security note:</strong></br>
         To receive information about updates and security issues, we recommend a subscription to our low-traffic <a href="http://mailman.nextcloud.org/mailman/listinfo/announcements">announcement mailing list</a>.</p>-->
-        <a name=""></a>
+        <a id=""></a>
         <p><?php echo $l->t('To <em>upgrade in the safest way possible</em>, always update to the latest minor release before upgrading to a new version. As an extreme example, to upgrade from 9 all the way to 12.0.5, upgrade 9.0.x to 9.0.6, then upgrade to 10.0.6, 11.0.7, then 12.0.5. We try to set up our updater to do this automatically for you whenever possible.');?></p>
     </div>
 <!--    <div class="col-lg-3 col-md-4 col-sm-6 col-xs-10">

--- a/page-secure.php
+++ b/page-secure.php
@@ -385,7 +385,7 @@
             </div>
         </div>
     </div>
-    <a name="videoverification"></a>
+    <a id="videoverification"></a>
     <div class="row">
         <div class="features--container">
             <div class="col-md-6 image--floated">
@@ -458,7 +458,7 @@
 </div>
 </section>
 
-<a name="process"></a>
+<a id="process"></a>
 <section class="section--process">
 <div class="container">
     <div class="featureblock process">

--- a/page-talk.php
+++ b/page-talk.php
@@ -121,7 +121,7 @@
 
 
 <section class="section--metadata">
-<a name="metadata"></a>
+<a id="metadata"></a>
 <div class="container">
    	<div class="row">
 		<div class="col-md-6">
@@ -150,7 +150,7 @@
 
 
 <section class="section--features">
-<a name="features" id="features"></a>
+<a id="features"></a>
 <div class="container-fluid quote">
     <div class="container">
         <h2 class="text-center"><?php echo $l->t('Key capabilities');?></h2>
@@ -459,7 +459,7 @@
 </section>
 
 <section class="section--scalability">
-<a name="scalability" id="scalability"></a>
+<a id="scalability"></a>
 <div class="container">
 	<div class="row">
 	<h1 class="text-center"><?php echo $l->t('Scalability');?></h1>
@@ -502,7 +502,7 @@
 
 
 <section class="section--options">
-<a name="hpb" id="hpb"></a>
+<a id="hpb"></a>
 <div class="container-widest">
 	<div class="row introduction">
         <div class="col-lg-6 col-lg-offset-3">
@@ -546,7 +546,7 @@
 </section>
 
 <section class="section--contact quote">
-<a name="pricing" id="pricing"></a>
+<a id="pricing"></a>
 <div class="container">
     <div class="row">
         <div class="col-md-6 col-md-offset-3">

--- a/page-trademarks.php
+++ b/page-trademarks.php
@@ -162,7 +162,7 @@ Our purpose here is to control the experience of Nextcloud business users. To be
 	<li>"Built on Nextcloud"</li>
 </ul>
 
-<a name="advertising"></a>
+<a id="advertising"></a>
 <h3>Advertising and Marketing Materials</h3>
 <p>You may use the Nextcloud Marks in describing and advertising your Nextcloud-related product or services like training, development and support, on websites, marketing materials or on business cards to identify your affiliation with the Nextcloud Community, so long as:</p>
 

--- a/page-training.php
+++ b/page-training.php
@@ -119,7 +119,7 @@
 </div>
 </section>
 
-<a name="program"></a>
+<a id="program"></a>
 <section class="section--training">
 <div class="container">
 	<div class="row">
@@ -292,9 +292,3 @@
 <!--     <p class="section--paragraph text-center"><a href="https://eventyay.com/e/b4dd4aab/" class="button button--blue button--arrow button--large">Register now!</a></p> -->
 </div>
 </section>
-
-
-
-
-
-


### PR DESCRIPTION
Remove and replace the deprecated `name` attribute on anchor elements with `id`

As detailed in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-name