### PR TITLE
Mention the latest Collabora doc and warn about recent virtualhost changes

### DIFF
--- a/page-collaboraonline.php
+++ b/page-collaboraonline.php
@@ -243,6 +243,7 @@
 				<li><code class="apache">a2enmod proxy_http</code></li>
 				<li><code class="apache">a2enmod ssl</code></li>
 			</ol>
+			<p class="section--paragraph"><?php echo $l->t('Warning, if you are using Nextcloud 23 (Nextcloud HUB II), the VirtualHost configuration has changed. You can find the latest installation information on <a href="%s">Collabora Online official documentation</a>', ['https://sdk.collaboraonline.com/docs/installation/Proxy_settings.html#reverse-proxy-with-apache-2-webserver']);?></p>
 			<p class="section--paragraph"><?php echo $l->t('Afterward, configure one VirtualHost properly to proxy the traffic. For security reason we recommend to use a subdomain such as office.nextcloud.com instead of running on the same domain. An example config can be found below:');?></p>
 			<p><pre>
 				<code class="apache">


### PR DESCRIPTION
The configuration we mention is not valid anymore with NC >= 23 and richdocuments >= 5.0.0 . This can affect all people having installed Collabora behind an Apache/NGinx reverse proxy. 

I'm not sure what exactly should change in this page. We could show the updated version of the VirtualHost config...or just mention the upstream documentation like in this PR.

Maybe the warning should appear earlier in the page. What do you think?

@juliushaertl Mentioned providing a migration guide. I don't know if it fits here though. I guess people visiting this page are newcomers only, they just need the fresh install instructions. 