### PR TITLE
jobs: Allow linking to specific opening

### DIFF
--- a/assets/js/pages/jobs.js
+++ b/assets/js/pages/jobs.js
@@ -1,14 +1,23 @@
-define(['jquery', 'lodash'],
+define(['jquery', 'lodash', 'bootstrap'],
 	function ($, _) {
 		$(document).ready(function() {
 			'use strict';
 			var jobsPage = {
 				init: function() {
+					var hash = window.location.hash;
+					if (hash) {
+						var collapsible = $(hash + '.collapse');
+						if(collapsible && collapsible.length){
+							collapsible.collapse('show');
+							collapsible.on('shown.bs.collapse', function() {
+								// scroll to header
+								$('a[href="' + hash + '"]')[0].scrollIntoView();
+								collapsible.off('shown.bs.collapse');
+							});
+						}
+					}
 				},
-
-				variables : {
-
-				}
+				variables: {}
 			};
 			jobsPage.init();
 		});

--- a/page-jobs.php
+++ b/page-jobs.php
@@ -2,7 +2,7 @@
 <link href="<?php echo get_template_directory_uri(); ?>/assets/css/pages/jobs.css?v=1" rel="stylesheet">
 	<script>
 	require(["require.config"], function() {
-		require(["bootstrap"])
+		require(["bootstrap", "pages/jobs"])
 	});
 	</script>
 </head>


### PR DESCRIPTION
When sending a job opening to someone, I found it odd that there was no clear way to link a specific position. For example https://nextcloud.com/jobs/#androiddev just opens the page at the top and doesn't uncollapse the section.

With this patch, the JS uncollapses the section and scrolls to the header.

Note: I used the existing `jobs.js` file which appeared unused, but I'm not that familiar with this page's structure. I'll change that if needed.

