### PR TITLE
improve the website navigation and discoverability of install options

### DIFF
--- a/install-instructions-server.php
+++ b/install-instructions-server.php
@@ -4,6 +4,14 @@
             <div class="row navigation-row">
                 <a href="#" class="close install-close">&times;</a>
                 <ul class="install-nav nav-tabs" role="tablist">
+                    <li>
+                        <a href="#tab-cloud" title="Provides automated updates" role="tab" data-toggle="tab">
+                            <div>
+                            <i class="fa-cloud"></i> <br />
+                            <?php echo $l->t('Appliances');?><br>
+                            </div>
+                        </a>
+                    </li>
                     <li id="li-tab-archive" class="active">
                         <a href="#tab-archive" title="For server owners" role="tab" data-toggle="tab">
                             <div>
@@ -17,14 +25,6 @@
                             <div>
                             <i class="fa-code"></i> <br />
                             <?php echo $l->t('Web Installer');?><br>
-                            </div>
-                        </a>
-                    </li>
-                    <li>
-                        <a href="#tab-cloud" title="Provides automated updates" role="tab" data-toggle="tab">
-                            <div>
-                            <i class="fa-cloud"></i> <br />
-                            <?php echo $l->t('Appliances');?><br>
                             </div>
                         </a>
                     </li>

--- a/install-instructions-server.php
+++ b/install-instructions-server.php
@@ -4,7 +4,7 @@
             <div class="row navigation-row">
                 <a href="#" class="close install-close">&times;</a>
                 <ul class="install-nav nav-tabs" role="tablist">
-                    <li>
+                    <li class="active">
                         <a href="#tab-cloud" title="Provides automated updates" role="tab" data-toggle="tab">
                             <div>
                             <i class="fa-cloud"></i> <br />
@@ -12,7 +12,7 @@
                             </div>
                         </a>
                     </li>
-                    <li id="li-tab-archive" class="active">
+                    <li id="li-tab-archive" >
                         <a href="#tab-archive" title="For server owners" role="tab" data-toggle="tab">
                             <div>
                             <i class="fa-archive"></i><br/>
@@ -32,7 +32,7 @@
             </div>
 
             <div  class="tab-content">
-                <div id="tab-archive" role="tabpanel" class="tab-pane active">
+                <div id="tab-archive" role="tabpanel" class="tab-pane">
                     <div class="overlay-body row">
                         <div class="col-md-6">
                             <p><?php echo $l->t('The <strong>archive</strong> should be extracted in a folder your web server has access to. Latest stable version');?>:  <?php echo $VERSIONS_SERVER_FULL_STABLE; ?> (<a class="hyperlink" href="<?php echo home_url('changelog') ?>"><small><?php echo $l->t('Changelog');?></small></a>)</br>
@@ -106,7 +106,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="tab-cloud" role="tabpanel" class="tab-pane">
+                <div id="tab-cloud" role="tabpanel" class="tab-pane active">
                     <div class="overlay-body row">
                         <div class="col-md-8">
                             <div class="row">

--- a/templates/header-top-navbar.php
+++ b/templates/header-top-navbar.php
@@ -252,16 +252,6 @@ require(["require.config"], function() {
                             </a>
                         </li>
                         <li class="nav__item">
-                            <a href="<?php echo home_url('install/#install-clients'); ?>">
-                                <div class="nav__logo">
-                                    <?php echo file_get_contents(__DIR__."/../assets/img/icons/phone.svg");?>
-                                </div>
-                                <div class="nav__text">
-                                    <?php echo $l->t('<strong>Desktop & mobile apps</strong><br><small>Windows, macOS, Linux, Android, iOS, …</small>'); ?>
-                                </div>
-                            </a>
-                        </li>
-                        <li class="nav__item">
                             <a href="<?php echo home_url('signup'); ?>">
                                 <div class="nav__logo">
                                     <?php echo file_get_contents(__DIR__."/../assets/img/icons/signup.svg");?>
@@ -284,10 +274,10 @@ require(["require.config"], function() {
                         <li class="nav__item">
                             <a href="<?php echo home_url('install/#instructions-server'); ?>">
                                 <div class="nav__logo">
-                                    <?php echo file_get_contents(__DIR__."/../assets/img/icons/server.svg");?>
+                                    <?php echo file_get_contents(__DIR__."/../assets/img/icons/download.svg");?>
                                 </div>
                                 <div class="nav__text">
-                                    <?php echo $l->t('<strong>Server packages</strong><br><small>For self-hosting on your server</small>'); ?>
+                                    <?php echo $l->t('<strong>Nextcloud server</strong><br><small>For self-hosting on your server</small>'); ?>
                                 </div>
                             </a>
                         </li>
@@ -298,6 +288,16 @@ require(["require.config"], function() {
                                 </div>
                                 <div class="nav__text">
                                     <?php echo $l->t('<strong>Devices</strong><br><small>Buy hardware with Nextcloud</small>'); ?>
+                                </div>
+                            </a>
+                        </li>
+                        <li class="nav__item">
+                            <a href="<?php echo home_url('install/#install-clients'); ?>">
+                                <div class="nav__logo">
+                                    <?php echo file_get_contents(__DIR__."/../assets/img/icons/phone.svg");?>
+                                </div>
+                                <div class="nav__text">
+                                    <?php echo $l->t('<strong>Desktop & mobile apps</strong><br><small>Windows, macOS, Linux, Android, iOS, …</small>'); ?>
                                 </div>
                             </a>
                         </li>

--- a/templates/header-top-navbar.php
+++ b/templates/header-top-navbar.php
@@ -252,6 +252,16 @@ require(["require.config"], function() {
                             </a>
                         </li>
                         <li class="nav__item">
+                            <a href="<?php echo home_url('install/#install-clients'); ?>">
+                                <div class="nav__logo">
+                                    <?php echo file_get_contents(__DIR__."/../assets/img/icons/phone.svg");?>
+                                </div>
+                                <div class="nav__text">
+                                    <?php echo $l->t('<strong>Desktop & mobile apps</strong><br><small>Windows, macOS, Linux, Android, iOS, …</small>'); ?>
+                                </div>
+                            </a>
+                        </li>
+                        <li class="nav__item">
                             <a href="<?php echo home_url('signup'); ?>">
                                 <div class="nav__logo">
                                     <?php echo file_get_contents(__DIR__."/../assets/img/icons/signup.svg");?>
@@ -288,16 +298,6 @@ require(["require.config"], function() {
                                 </div>
                                 <div class="nav__text">
                                     <?php echo $l->t('<strong>Devices</strong><br><small>Buy hardware with Nextcloud</small>'); ?>
-                                </div>
-                            </a>
-                        </li>
-                        <li class="nav__item">
-                            <a href="<?php echo home_url('install/#install-clients'); ?>">
-                                <div class="nav__logo">
-                                    <?php echo file_get_contents(__DIR__."/../assets/img/icons/phone.svg");?>
-                                </div>
-                                <div class="nav__text">
-                                    <?php echo $l->t('<strong>Desktop & mobile apps</strong><br><small>Windows, macOS, Linux, Android, iOS, …</small>'); ?>
                                 </div>
                             </a>
                         </li>


### PR DESCRIPTION
Four improvements:
1. improve order of options for "Get Nextcloud" menu
2. Change the description from server packages to Nextcloud server (I wouldn't know what server packages shall be)
3. Change the icon from a random icon to a download icon for this option which will make things more obvious and better to discover
4. in install-instructions menu, move appliances to be the first option since it should be the recommended way to install Nextcloud and not by using an archive or the webinstaller.

My basic idea about this PR was that a few years ago when I was new to Nextcloud and looked at the website to self-host my own server I didn't find the appliances because they are not easy to find. (Because of that I thought it was much too complicated for me and needed a few months until I had another look and found the appliances). This makes it hopefully much more easy to discover them.

Signed-off-by: szaimen <szaimen@e.mail.de>