### PR TITLE
Update collaboraonline

### DIFF
--- a/page-collaboraonline.php
+++ b/page-collaboraonline.php
@@ -223,7 +223,7 @@
 			</ol>
 			<p class="section--paragraph"><?php echo $l->t('<strong>Note:</strong> This guide does <em>NOT</em> cover self-signed certificates. If you use a self-signed certificate then you\'re mostly on your own ;-)');?></p>
 			<h3 class="section--paragraph__title"><?php echo $l->t('1. Install the Collabora Online server');?></h3>
-			<p class="section--paragraph"><?php echo $l->t('The following steps will download the Collabora Online docker, make sure to replace "cloud.nextcloud.com" with the host that your own Nextcloud runs on. Also make sure to escape all dots with double backslashes (<code>\\</code>), since this string will be evaluated as a regular expression (and your bash \'eats\' the first backslash.) If you want to use the docker container with more than one Nextcloud, you\'ll need to use');?> <code>'domain=cloud\\.nextcloud\\.com\|second\\.nextcloud\\.com'</code> <?php echo $l->t('instead. (All hosts are separated by <code>\|</code>.)');?></p>
+			<p class="section--paragraph"><?php echo $l->t('The following steps will download the Collabora Online docker, make sure to replace "cloud.nextcloud.com" with the host that your own Nextcloud runs on. If you want to use the docker container with more than one Nextcloud, you\'ll need to use');?> <code>'-e "aliasgroup1=https://<domain1>:443,https://<your-dot-escaped-aliasname1>|<your-dot-escaped-aliasname2>:443" -e "aliasgroup2=https://<domain2>:443"'</code> <?php echo $l->t('instead.');?></p>
 			<p><pre><code class="docker">
                 docker pull collabora/code
                 docker run -t -d -p 127.0.0.1:9980:9980 -e 'aliasgroup1=https://cloud.nextcloud.com:443' --restart always --cap-add MKNOD collabora/code
@@ -243,7 +243,6 @@
 				<li><code class="apache">a2enmod proxy_http</code></li>
 				<li><code class="apache">a2enmod ssl</code></li>
 			</ol>
-			<p class="section--paragraph"><?php echo $l->t('Warning, if you are using Nextcloud 23 (Nextcloud HUB II), the VirtualHost configuration has changed. You can find the latest installation information on <a href="%s">Collabora Online official documentation</a>', ['https://sdk.collaboraonline.com/docs/installation/Proxy_settings.html#reverse-proxy-with-apache-2-webserver']);?></p>
 			<p class="section--paragraph"><?php echo $l->t('Afterward, configure one VirtualHost properly to proxy the traffic. For security reason we recommend to use a subdomain such as office.nextcloud.com instead of running on the same domain. An example config can be found below:');?></p>
 			<p><pre>
 				<code class="apache">
@@ -296,7 +295,7 @@ ProxyPassReverse    /hosting/capabilities https://127.0.0.1:9980/hosting/capabil
 &lt;/VirtualHost&gt;
 			</code></pre></p>
 			<a id="update"></a>
-			<p class="section--paragraph"><?php echo $l->t('After configuring these do restart your apache using <code>/etc/init.d/apache2 restart</code>.');?></p>
+			<p class="section--paragraph"><?php echo $l->t('After configuring these do restart your apache using <code>systemctl restart apache2.service</code>.');?></p>
 			<h3 class="section--paragraph__title"><?php echo $l->t('3. Configure the app in Nextcloud');?></h3>
 			<ol>
 				<li class="section--paragraph"><?php echo $l->t('Go to the Apps section and choose "Office & text"');?></li>

--- a/page-collaboraonline.php
+++ b/page-collaboraonline.php
@@ -271,24 +271,24 @@ SSLProxyCheckPeerName Off
 # keep the host
 ProxyPreserveHost On
 
-# static html, js, images, etc. served from loolwsd
-# loleaflet is the client part of LibreOffice Online
-ProxyPass           /loleaflet https://127.0.0.1:9980/loleaflet retry=0
-ProxyPassReverse    /loleaflet https://127.0.0.1:9980/loleaflet
+# static html, js, images, etc. served from coolwsd
+# browser is the client part of LibreOffice Online
+ProxyPass           /browser https://127.0.0.1:9980/browser retry=0
+ProxyPassReverse    /browser https://127.0.0.1:9980/browser
 
 # WOPI discovery URL
 ProxyPass           /hosting/discovery https://127.0.0.1:9980/hosting/discovery retry=0
 ProxyPassReverse    /hosting/discovery https://127.0.0.1:9980/hosting/discovery
 
 # Main websocket
-ProxyPassMatch "/lool/(.*)/ws$" wss://127.0.0.1:9980/lool/$1/ws nocanon
+ProxyPassMatch "/cool/(.*)/ws$" wss://127.0.0.1:9980/cool/$1/ws nocanon
 
 # Admin Console websocket
-ProxyPass   /lool/adminws wss://127.0.0.1:9980/lool/adminws
+ProxyPass   /cool/adminws wss://127.0.0.1:9980/cool/adminws
 
 # Download as, Fullscreen presentation and Image upload operations
-ProxyPass           /lool https://127.0.0.1:9980/lool
-ProxyPassReverse    /lool https://127.0.0.1:9980/lool
+ProxyPass           /cool https://127.0.0.1:9980/cool
+ProxyPassReverse    /cool https://127.0.0.1:9980/cool
 
 # Endpoint with information about availability of various features
 ProxyPass           /hosting/capabilities https://127.0.0.1:9980/hosting/capabilities retry=0

--- a/page-collaboraonline.php
+++ b/page-collaboraonline.php
@@ -226,11 +226,11 @@
 			<p class="section--paragraph"><?php echo $l->t('The following steps will download the Collabora Online docker, make sure to replace "cloud.nextcloud.com" with the host that your own Nextcloud runs on. Also make sure to escape all dots with double backslashes (<code>\\</code>), since this string will be evaluated as a regular expression (and your bash \'eats\' the first backslash.) If you want to use the docker container with more than one Nextcloud, you\'ll need to use');?> <code>'domain=cloud\\.nextcloud\\.com\|second\\.nextcloud\\.com'</code> <?php echo $l->t('instead. (All hosts are separated by <code>\|</code>.)');?></p>
 			<p><pre><code class="docker">
                 docker pull collabora/code
-                docker run -t -d -p 127.0.0.1:9980:9980 -e 'domain=cloud\\.nextcloud\\.com' --restart always --cap-add MKNOD collabora/code
+                docker run -t -d -p 127.0.0.1:9980:9980 -e 'aliasgroup1=https://cloud.nextcloud.com:443' --restart always --cap-add MKNOD collabora/code
 			</code></pre></p>
 			<p class="section--paragraph"><?php echo $l->t('Optionally, you can select the dictionaries you want with:');?></p>
             <p><pre><code class="docker">
-                docker run -t -d -p 127.0.0.1:9980:9980 -e 'domain=cloud\\.nextcloud\\.com' -e 'dictionaries=de en es ..' --restart always --cap-add MKNOD collabora/code
+                docker run -t -d -p 127.0.0.1:9980:9980 -e 'aliasgroup1=https://cloud.nextcloud.com:443' -e 'dictionaries=de en es ..' --restart always --cap-add MKNOD collabora/code
             </code></pre></p>
             <p class="section--paragraph"><?php echo $l->t('This way you are not only limited to German, English, Italian, French and Spanish.');?></p>
 			<p class="section--paragraph"><?php echo $l->t('That will be enough. Once you have done that the server will listen on "localhost:9980". Now we just need to configure the locally installed Apache reverse proxy.');?></p>
@@ -326,7 +326,7 @@ docker rm CONTAINER_ID
 				</code></li>
 			<li class="section--paragraph"><?php echo $l->t('start the new image:<br/>');?>
 			<code class="docker">
-docker run -t -d -p 127.0.0.1:9980:9980 -e 'domain=cloud\\.nextcloud\\.com' --restart always --cap-add MKNOD collabora/code
+docker run -t -d -p 127.0.0.1:9980:9980 -e 'aliasgroup1=https://cloud.nextcloud.com:443' --restart always --cap-add MKNOD collabora/code
 			</code></li>
 			</ul>
 			<p class="section--paragraph"><?php echo $l->t('Enjoy!');?></p>


### PR DESCRIPTION
Hi,

the CODE-guide https://nextcloud.com/collaboraonline/ is outdated right now.

- It does not reflect the changes to the VirtualHost since NC23
- It does not reflect changes to start the docker container for recent CODE docker images.

This adresses https://github.com/nextcloud/nextcloud.com/issues/1575

This is my first PR, advice is welcome, please don't be too harsh :-)

Best regards!