### PR TITLE
Bump up minimum macOS version to 10.14

### DIFF
--- a/install-instructions-clients.php
+++ b/install-instructions-clients.php
@@ -29,7 +29,7 @@
 <!-- 							<p><?php echo $l->t('Latest stable version:');?> <?php echo $VERSIONS_CLIENT_DESKTOP_STABLE_FULL; ?>&nbsp;<a href="https://github.com/nextcloud/desktop/releases"><?php echo $l->t('changelog');?></a>&nbsp;</p> -->
 							<p><?php echo $l->t('Use the desktop clients to keep your files synchronized between your Nextcloud server and your desktop. Select one or more directories on your local machine and always have access to your latest files wherever you are.');?> <a class="hyperlink" href="<?php echo home_url('clients');?>"><?php echo $l->t('Learn more about our clients here.');?></a></p>
 							<a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_STABLE_WIN; ?>" id="client-download-win" class="button button--white"><i class="fa-windows"></i>  Windows<br /><small>8.1+</small></a>
-							<a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_STABLE_MAC; ?>" id="client-download-mac" class="button button--white"><i class="fa-apple"></i> macOS<br /><small>10.13+, 64 bit</small></a>
+							<a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_STABLE_MAC; ?>" id="client-download-mac" class="button button--white"><i class="fa-apple"></i> macOS<br /><small>10.14+, 64 bit</small></a>
 							<a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_STABLE_LINUX; ?>" id="client-download-linux" class="button button--white"><i class="fa-linux"></i> Linux<br /><small>AppImage</small></a>
 							<br>
 							<p><i class="fa-apple"></i>&nbsp;<a href="<?php echo $DOWNLOAD_CLIENT_DESKTOP_STABLE_MAC_LEGACY; ?>">Mac OS 10.10+ (legacy)</a></p>


### PR DESCRIPTION
Due to the client's new notification system, the minimum required version is 10.14